### PR TITLE
Add SSRF protection, HTTP timeout, and access logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ markdown-proxy [options]
 | `--port`, `-p` | Listen port | `9080` |
 | `--theme` | Default CSS theme (`github`, `simple`, `dark`) | `github` |
 | `--plantuml-server` | PlantUML server URL | `https://www.plantuml.com/plantuml` |
+| `--allow-private-network` | Allow fetching from private/internal IP addresses | `false` |
+| `--verbose`, `-v` | Enable access logging | `false` |
+
+## Security
+
+- **Localhost-only**: The server binds to `127.0.0.1` only. It is not intended for network-facing deployment.
+- **SSRF protection**: By default, requests to private/internal IP addresses (e.g., `10.x.x.x`, `192.168.x.x`, `127.x.x.x`) are blocked when fetching remote files. Use `--allow-private-network` to disable this restriction.
+- **DNS rebinding prevention**: Resolved IP addresses are used directly for connections, preventing DNS rebinding attacks.
 
 ## Build
 
@@ -76,6 +84,7 @@ internal/
   config/              - Command-line flag parsing
   server/              - HTTP server and routing
   handler/             - Request handlers (top, local, remote)
+  network/             - HTTP client with SSRF protection
   markdown/            - Markdown→HTML conversion, link rewriting, code block processing
   credential/          - git credential helper integration
   github/              - GitHub/GitLab URL resolution

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,9 +3,11 @@ package config
 import "flag"
 
 type Config struct {
-	Port           int
-	Theme          string
-	PlantUMLServer string
+	Port                int
+	Theme               string
+	PlantUMLServer      string
+	AllowPrivateNetwork bool
+	Verbose             bool
 }
 
 func Parse() *Config {
@@ -14,6 +16,9 @@ func Parse() *Config {
 	flag.IntVar(&c.Port, "p", 9080, "Listen port (shorthand)")
 	flag.StringVar(&c.Theme, "theme", "github", "Default CSS theme")
 	flag.StringVar(&c.PlantUMLServer, "plantuml-server", "https://www.plantuml.com/plantuml", "PlantUML server URL")
+	flag.BoolVar(&c.AllowPrivateNetwork, "allow-private-network", false, "Allow fetching from private/internal IP addresses")
+	flag.BoolVar(&c.Verbose, "verbose", false, "Enable access logging")
+	flag.BoolVar(&c.Verbose, "v", false, "Enable access logging (shorthand)")
 	flag.Parse()
 	return c
 }

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -16,11 +16,12 @@ import (
 )
 
 type RemoteHandler struct {
-	cfg *config.Config
+	cfg    *config.Config
+	client *http.Client
 }
 
-func NewRemoteHandler(cfg *config.Config) *RemoteHandler {
-	return &RemoteHandler{cfg: cfg}
+func NewRemoteHandler(cfg *config.Config, client *http.Client) *RemoteHandler {
+	return &RemoteHandler{cfg: cfg, client: client}
 }
 
 func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +183,7 @@ func (h *RemoteHandler) doFetch(remoteURL, username, password string) ([]byte, s
 		req.Header.Set("Authorization", "token "+password)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := h.client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/network/safeclient.go
+++ b/internal/network/safeclient.go
@@ -1,0 +1,78 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+)
+
+var privateCIDRs []*net.IPNet
+
+func init() {
+	cidrs := []string{
+		"127.0.0.0/8",
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16",
+		"::1/128",
+		"fc00::/7",
+		"fe80::/10",
+	}
+	for _, cidr := range cidrs {
+		_, ipNet, _ := net.ParseCIDR(cidr)
+		privateCIDRs = append(privateCIDRs, ipNet)
+	}
+}
+
+func isPrivateIP(ip net.IP) bool {
+	for _, cidr := range privateCIDRs {
+		if cidr.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// NewSafeClient returns an *http.Client with a 30-second timeout.
+// When allowPrivate is false, connections to private/internal IP addresses
+// are blocked to prevent SSRF attacks. DNS resolution results are used
+// directly for dialing to prevent DNS rebinding.
+func NewSafeClient(allowPrivate bool) *http.Client {
+	dialer := &net.Dialer{
+		Timeout: 10 * time.Second,
+	}
+
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("no IP addresses found for %s", host)
+			}
+
+			ip := ips[0].IP
+			if !allowPrivate && isPrivateIP(ip) {
+				return nil, fmt.Errorf("access to private IP address %s (%s) is blocked", ip, host)
+			}
+
+			// Connect using resolved IP directly (prevents DNS rebinding)
+			resolvedAddr := net.JoinHostPort(ip.String(), port)
+			return dialer.DialContext(ctx, network, resolvedAddr)
+		},
+	}
+
+	return &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,24 +4,52 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/patakuti/markdown-proxy/internal/config"
 	"github.com/patakuti/markdown-proxy/internal/handler"
+	"github.com/patakuti/markdown-proxy/internal/network"
 )
 
 func Run(cfg *config.Config) error {
 	mux := http.NewServeMux()
 
+	client := network.NewSafeClient(cfg.AllowPrivateNetwork)
+
 	topHandler := handler.NewTopHandler(cfg)
 	localHandler := handler.NewLocalHandler(cfg)
-	remoteHandler := handler.NewRemoteHandler(cfg)
+	remoteHandler := handler.NewRemoteHandler(cfg, client)
 
 	mux.HandleFunc("/", topHandler.ServeHTTP)
 	mux.HandleFunc("/local/", localHandler.ServeHTTP)
 	mux.HandleFunc("/http/", remoteHandler.ServeHTTP)
 	mux.HandleFunc("/https/", remoteHandler.ServeHTTP)
 
+	var h http.Handler = mux
+	if cfg.Verbose {
+		h = loggingMiddleware(mux)
+	}
+
 	addr := fmt.Sprintf("127.0.0.1:%d", cfg.Port)
 	log.Printf("Starting markdown-proxy on %s", addr)
-	return http.ListenAndServe(addr, mux)
+	return http.ListenAndServe(addr, h)
+}
+
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rw, r)
+		log.Printf("%s %s %d %s", r.Method, r.URL.Path, rw.statusCode, time.Since(start))
+	})
 }


### PR DESCRIPTION
## Summary
- Add `internal/network` package with safe HTTP client that blocks private IP addresses by default and prevents DNS rebinding attacks
- Add `--allow-private-network` flag to permit fetching from private/internal IPs
- Add `--verbose` / `-v` flag to enable request logging middleware (method, path, status, duration)
- Inject HTTP client into `RemoteHandler` instead of using `http.DefaultClient`
- Update README with new flags, Security section, and project structure

## Test plan
- [x] `make build` succeeds
- [x] `markdown-proxy --help` shows new flags
- [x] `markdown-proxy -v` logs access requests with method, path, status, and duration
- [x] Remote file fetching works normally (public URLs)
- [x] Private IP addresses are blocked by default
- [x] `--allow-private-network` allows private IP access

🤖 Generated with [Claude Code](https://claude.com/claude-code)