### PR TITLE
Add live reload for local files using SSE + fsnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A local HTTP proxy server for viewing Markdown files in a browser.
   - Blob URL auto-conversion to raw URL
   - Authentication via git credential helper (on 401/403 only)
 - Multiple CSS themes (GitHub, Simple, Dark) with switching UI
+- Live reload for local files (auto-refreshes browser on file changes)
 - Directory listing for local files
 - Link rewriting for seamless proxy navigation
 - Top page with smart input (auto-detects file path or URL)
@@ -47,6 +48,14 @@ markdown-proxy [options]
 | `--plantuml-server` | PlantUML server URL | `https://www.plantuml.com/plantuml` |
 | `--allow-private-network` | Allow fetching from private/internal IP addresses | `false` |
 | `--verbose`, `-v` | Enable access logging | `false` |
+
+## Live Reload
+
+When viewing local Markdown files or directories (`/local/...`), the browser automatically reloads when the file or directory contents change. This uses Server-Sent Events (SSE) with filesystem notifications (fsnotify).
+
+- **Local files only**: Remote files (`/http/...`, `/https/...`) are not affected
+- **No configuration needed**: Works automatically for all local file views
+- **Debounced**: Multiple rapid changes are coalesced into a single reload (100ms debounce)
 
 ## Security
 
@@ -83,7 +92,7 @@ cmd/markdown-proxy/    - Entry point
 internal/
   config/              - Command-line flag parsing
   server/              - HTTP server and routing
-  handler/             - Request handlers (top, local, remote)
+  handler/             - Request handlers (top, local, remote, SSE)
   network/             - HTTP client with SSRF protection
   markdown/            - Markdown→HTML conversion, link rewriting, code block processing
   credential/          - git credential helper integration

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.22.2
 require (
 	github.com/alecthomas/chroma/v2 v2.2.0 // indirect
 	github.com/dlclark/regexp2 v1.7.0 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/yuin/goldmark v1.7.16 // indirect
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc // indirect
+	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -14,5 +16,7 @@ github.com/yuin/goldmark v1.7.16 h1:n+CJdUxaFMiDUNnWC3dMWCIQJSkxH4uz3ZwQBkAlVNE=
 github.com/yuin/goldmark v1.7.16/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc h1:+IAOyRda+RLrxa1WC7umKOZRsGq4QrFFMYApOeHzQwQ=
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc/go.mod h1:ovIvrum6DQJA4QsJSovrkC4saKHQVs7TvcaeO8AIl5I=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/handler/local.go
+++ b/internal/handler/local.go
@@ -92,9 +92,10 @@ func (h *LocalHandler) serveFile(w http.ResponseWriter, filePath string) {
 	htmlContent = markdown.RewriteLinks(htmlContent, "local", "")
 
 	page, err := tmpl.RenderMarkdown(&tmpl.PageData{
-		Title:   filepath.Base(filePath),
-		Content: template.HTML(htmlContent),
-		Theme:   h.cfg.Theme,
+		Title:     filepath.Base(filePath),
+		Content:   template.HTML(htmlContent),
+		Theme:     h.cfg.Theme,
+		WatchPath: filePath,
 	})
 	if err != nil {
 		http.Error(w, "Error rendering page: "+err.Error(), http.StatusInternalServerError)
@@ -149,10 +150,11 @@ func (h *LocalHandler) serveDirectory(w http.ResponseWriter, dirPath string) {
 	}
 
 	page, err := tmpl.RenderDirectory(&tmpl.DirPageData{
-		Title:   dirPath,
-		Path:    dirPath,
-		Entries: dirEntries,
-		Theme:   h.cfg.Theme,
+		Title:     dirPath,
+		Path:      dirPath,
+		Entries:   dirEntries,
+		Theme:     h.cfg.Theme,
+		WatchPath: dirPath,
 	})
 	if err != nil {
 		http.Error(w, "Error rendering directory: "+err.Error(), http.StatusInternalServerError)

--- a/internal/handler/sse.go
+++ b/internal/handler/sse.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type SSEHandler struct{}
+
+func NewSSEHandler() *SSEHandler {
+	return &SSEHandler{}
+}
+
+func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	watchPath := r.URL.Query().Get("path")
+	if watchPath == "" {
+		http.Error(w, "missing path parameter", http.StatusBadRequest)
+		return
+	}
+
+	info, err := os.Stat(watchPath)
+	if err != nil {
+		http.Error(w, "path not found: "+watchPath, http.StatusNotFound)
+		return
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		http.Error(w, "failed to create watcher: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer watcher.Close()
+
+	if info.IsDir() {
+		err = watcher.Add(watchPath)
+	} else {
+		// Watch the parent directory to catch file renames/recreations
+		err = watcher.Add(filepath.Dir(watchPath))
+	}
+	if err != nil {
+		http.Error(w, "failed to watch path: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	flusher.Flush()
+
+	ctx := r.Context()
+	debounceCh := make(chan struct{}, 1)
+	var debounceTimer *time.Timer
+
+	for {
+		select {
+		case <-ctx.Done():
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			return
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return
+			}
+			// For files, only react to events for the target file
+			if !info.IsDir() && filepath.Clean(event.Name) != filepath.Clean(watchPath) {
+				continue
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename) == 0 {
+				continue
+			}
+			// Debounce: reset timer on each event, send after 100ms of quiet
+			if debounceTimer != nil {
+				debounceTimer.Stop()
+			}
+			debounceTimer = time.AfterFunc(100*time.Millisecond, func() {
+				select {
+				case debounceCh <- struct{}{}:
+				default:
+				}
+			})
+		case <-debounceCh:
+			fmt.Fprintf(w, "data: reload\n\n")
+			flusher.Flush()
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("watcher error: %v", err)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,11 +19,13 @@ func Run(cfg *config.Config) error {
 	topHandler := handler.NewTopHandler(cfg)
 	localHandler := handler.NewLocalHandler(cfg)
 	remoteHandler := handler.NewRemoteHandler(cfg, client)
+	sseHandler := handler.NewSSEHandler()
 
 	mux.HandleFunc("/", topHandler.ServeHTTP)
 	mux.HandleFunc("/local/", localHandler.ServeHTTP)
 	mux.HandleFunc("/http/", remoteHandler.ServeHTTP)
 	mux.HandleFunc("/https/", remoteHandler.ServeHTTP)
+	mux.HandleFunc("/_sse", sseHandler.ServeHTTP)
 
 	var h http.Handler = mux
 	if cfg.Verbose {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -6,9 +6,10 @@ import (
 )
 
 type PageData struct {
-	Title   string
-	Content template.HTML
-	Theme   string
+	Title     string
+	Content   template.HTML
+	Theme     string
+	WatchPath string
 }
 
 type DirEntry struct {
@@ -18,10 +19,11 @@ type DirEntry struct {
 }
 
 type DirPageData struct {
-	Title   string
-	Path    string
-	Entries []DirEntry
-	Theme   string
+	Title     string
+	Path      string
+	Entries   []DirEntry
+	Theme     string
+	WatchPath string
 }
 
 func RenderMarkdown(data *PageData) ([]byte, error) {
@@ -97,6 +99,18 @@ function switchTheme(theme) {
   }
 })();
 </script>
+{{if .WatchPath}}
+<script>
+(function() {
+  var es = new EventSource('/_sse?path=' + encodeURIComponent('{{.WatchPath}}'));
+  es.onmessage = function(e) {
+    if (e.data === 'reload') {
+      location.reload();
+    }
+  };
+})();
+</script>
+{{end}}
 </body>
 </html>`
 
@@ -151,5 +165,17 @@ function switchTheme(theme) {
   }
 })();
 </script>
+{{if .WatchPath}}
+<script>
+(function() {
+  var es = new EventSource('/_sse?path=' + encodeURIComponent('{{.WatchPath}}'));
+  es.onmessage = function(e) {
+    if (e.data === 'reload') {
+      location.reload();
+    }
+  };
+})();
+</script>
+{{end}}
 </body>
 </html>`


### PR DESCRIPTION
## Summary
- Add automatic browser refresh when local Markdown files or directories change
- Uses Server-Sent Events (SSE) with filesystem notifications (fsnotify) and 100ms debounce
- Only applies to `/local/...` paths; remote files are unaffected (no SSE script injected)

## Changes
- `go.mod` / `go.sum`: Add `github.com/fsnotify/fsnotify` dependency
- `internal/handler/sse.go`: New SSE endpoint handler (`/_sse?path=...`)
- `internal/template/template.go`: Add `WatchPath` field and SSE JavaScript to templates
- `internal/handler/local.go`: Set `WatchPath` for file and directory views
- `internal/server/server.go`: Register `/_sse` route
- `README.md`: Document Live Reload feature

## Test plan
- [x] `make build` succeeds
- [x] Open a local Markdown file, edit and save it → browser auto-reloads
- [x] Open a local directory, add/delete a file → browser auto-reloads
- [x] Open a remote file → confirm no SSE `<script>` in HTML source

🤖 Generated with [Claude Code](https://claude.com/claude-code)