### PR TITLE
Fix Windows drive letter path handling in local file handler

### DIFF
--- a/internal/handler/local.go
+++ b/internal/handler/local.go
@@ -29,6 +29,11 @@ func (h *LocalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		filePath = "/"
 	}
 
+	// Strip leading "/" before Windows drive letter (e.g. /C:/path → C:/path)
+	if len(filePath) >= 3 && filePath[0] == '/' && isLetter(filePath[1]) && filePath[2] == ':' {
+		filePath = filePath[1:]
+	}
+
 	// Expand ~ to home directory
 	if strings.HasPrefix(filePath, "/~/") {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -116,12 +121,13 @@ func (h *LocalHandler) serveDirectory(w http.ResponseWriter, dirPath string) {
 	var dirEntries []tmpl.DirEntry
 
 	// Add parent directory link if not at root
-	if dirPath != "/" {
+	// filepath.Dir returns the path itself for both Unix root (/) and Windows drive root (C:\)
+	if filepath.Dir(dirPath) != dirPath {
 		parent := filepath.Dir(dirPath)
 		dirEntries = append(dirEntries, tmpl.DirEntry{
 			Name:  "..",
 			IsDir: true,
-			URL:   "/local" + parent,
+			URL:   "/local/" + strings.TrimPrefix(filepath.ToSlash(parent), "/"),
 		})
 	}
 
@@ -138,7 +144,7 @@ func (h *LocalHandler) serveDirectory(w http.ResponseWriter, dirPath string) {
 		if strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-		url := "/local" + filepath.Join(dirPath, entry.Name())
+		url := "/local/" + strings.TrimPrefix(filepath.ToSlash(filepath.Join(dirPath, entry.Name())), "/")
 		if entry.IsDir() {
 			url += "/"
 		}
@@ -163,4 +169,9 @@ func (h *LocalHandler) serveDirectory(w http.ResponseWriter, dirPath string) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write(page)
+}
+
+// isLetter reports whether c is an ASCII letter.
+func isLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }


### PR DESCRIPTION
## Summary
- Fix `CreateFile \C:\path\to\file.md: The filename, directory name, or volume label syntax is incorrect` error on Windows
- Strip leading `/` before Windows drive letter patterns in URL-to-filepath conversion
- Use `filepath.Dir(dirPath) != dirPath` for cross-platform root directory detection (Unix `/` and Windows `C:\`)
- Use `filepath.ToSlash` for directory listing URL construction to prevent backslashes in URLs

## Test plan
- [x] `go build ./...` passes
- [x] Verify on Windows: `/local/C:/Users/test/file.md` resolves to `C:\Users\test\file.md`
- [x] Verify on Linux: `/local/home/user/file.md` resolves to `/home/user/file.md` (no regression)
- [x] Verify directory listing URLs use `/` separators on both platforms
- [x] Verify parent directory (`..`) link works at drive root (e.g. `C:\`) — should not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)