### PR TITLE
Add remote access mode with token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # markdown-proxy
 
-A local HTTP proxy server for viewing Markdown files in a browser.
+An HTTP proxy server for viewing Markdown files in a browser. Supports both local and remote access modes.
 
 ## Features
 
@@ -20,7 +20,9 @@ A local HTTP proxy server for viewing Markdown files in a browser.
 - Link rewriting for seamless proxy navigation
 - Top page with smart input (auto-detects file path or URL)
 - Recently opened file history (localStorage)
-- Localhost-only binding (127.0.0.1) for security
+- Two operation modes: local mode and remote mode
+- Token-based authentication for remote access
+- Access logging with automatic log rotation
 - Single binary, no runtime dependencies
 
 ## URL Scheme
@@ -45,16 +47,65 @@ markdown-proxy [options]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--port`, `-p` | Listen port | `9080` |
+| `--listen` | Bind address (`127.0.0.1` for local, `0.0.0.0` for remote) | `127.0.0.1` |
 | `--theme` | Default CSS theme (`github`, `simple`, `dark`) | `github` |
 | `--plantuml-server` | PlantUML server URL | `https://www.plantuml.com/plantuml` |
-| `--allow-private-network` | Allow fetching from private/internal IP addresses | `false` |
-| `--verbose`, `-v` | Enable access logging | `false` |
+| `--auth-token` | Authentication token (required in remote mode) | |
+| `--auth-cookie-max-age` | Authentication cookie max age in days | `30` |
+| `--access-log` | Access log file path | |
+| `--access-log-max-size` | Max log file size in MB before rotation | `100` |
+| `--access-log-max-backups` | Max number of old log files to retain | `3` |
+| `--access-log-max-age` | Max days to retain old log files | `28` |
+| `--verbose`, `-v` | Enable debug logging to stderr | `false` |
+
+## Operation Modes
+
+### Local Mode (default)
+
+```bash
+markdown-proxy
+```
+
+The server binds to `127.0.0.1` and all features are available:
+- Local file access (`/local/...`)
+- Remote file access (`/http/...`, `/https/...`)
+- Live reload via SSE (`/_sse`)
+- Private network access is allowed for remote file fetching
+
+### Remote Mode
+
+```bash
+markdown-proxy --listen 0.0.0.0 --auth-token my-secret-token
+```
+
+The server binds to the specified address for network access. For security:
+- **Local file access is disabled**: `/local/` and `/_sse` return 403 Forbidden
+- **Authentication is required**: `--auth-token` must be specified
+- **Private network access is blocked**: SSRF protection prevents fetching from internal IPs
+- **Top page** shows URL input only (no local file path input)
+
+Users must authenticate via a login page (`/_login`) by entering the access token. The token is stored in an HttpOnly cookie for the configured duration.
+
+## Access Logging
+
+Access logs record each request in the following format:
+
+```
+2026-02-22T15:04:05+09:00 192.168.1.10 GET /https/github.com/user/repo 200 1234 150ms
+```
+
+- `--access-log /var/log/mdproxy/access.log`: Log to a file with automatic rotation
+- In remote mode without `--access-log`: Logs to stdout by default
+- In local mode without `--access-log`: No access logging
+
+Log rotation is handled automatically using configurable size, count, and age limits.
 
 ## Live Reload
 
 When viewing local Markdown files or directories (`/local/...`), the browser automatically reloads when the file or directory contents change. This uses Server-Sent Events (SSE) with filesystem notifications (fsnotify).
 
 - **Local files only**: Remote files (`/http/...`, `/https/...`) are not affected
+- **Local mode only**: Not available in remote mode
 - **No configuration needed**: Works automatically for all local file views
 - **Debounced**: Multiple rapid changes are coalesced into a single reload (100ms debounce)
 
@@ -69,9 +120,11 @@ No configuration needed. Math expressions are automatically detected and rendere
 
 ## Security
 
-- **Localhost-only**: The server binds to `127.0.0.1` only. It is not intended for network-facing deployment.
-- **SSRF protection**: By default, requests to private/internal IP addresses (e.g., `10.x.x.x`, `192.168.x.x`, `127.x.x.x`) are blocked when fetching remote files. Use `--allow-private-network` to disable this restriction.
-- **DNS rebinding prevention**: Resolved IP addresses are used directly for connections, preventing DNS rebinding attacks.
+- **Local mode**: The server binds to `127.0.0.1` only, accepting local connections only
+- **Remote mode**: Authentication is enforced via token. Local file access and private network fetching are automatically disabled
+- **SSRF protection**: In remote mode, requests to private/internal IP addresses (e.g., `10.x.x.x`, `192.168.x.x`, `127.x.x.x`) are blocked. In local mode, private network access is allowed
+- **DNS rebinding prevention**: Resolved IP addresses are used directly for connections, preventing DNS rebinding attacks
+- **Constant-time token comparison**: Authentication uses `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
 
 ## Build
 
@@ -100,9 +153,9 @@ go build -o markdown-proxy ./cmd/markdown-proxy
 ```
 cmd/markdown-proxy/    - Entry point
 internal/
-  config/              - Command-line flag parsing
-  server/              - HTTP server and routing
-  handler/             - Request handlers (top, local, remote, SSE)
+  config/              - Command-line flag parsing, mode detection
+  server/              - HTTP server, routing, middleware (auth, access log)
+  handler/             - Request handlers (top, local, remote, SSE, login)
   network/             - HTTP client with SSRF protection
   markdown/            - Markdown→HTML conversion, link rewriting, code block processing
   credential/          - git credential helper integration

--- a/cmd/markdown-proxy/main.go
+++ b/cmd/markdown-proxy/main.go
@@ -9,6 +9,9 @@ import (
 
 func main() {
 	cfg := config.Parse()
+	if err := cfg.Validate(); err != nil {
+		log.Fatal(err)
+	}
 	if err := server.Run(cfg); err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/yuin/goldmark v1.7.16 // indirect
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc // indirect
 	golang.org/x/sys v0.13.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,4 +23,6 @@ github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc/go.m
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,24 +1,54 @@
 package config
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+)
 
 type Config struct {
-	Port                int
-	Theme               string
-	PlantUMLServer      string
-	AllowPrivateNetwork bool
-	Verbose             bool
+	Port             int
+	Listen           string
+	Theme            string
+	PlantUMLServer   string
+	Verbose          bool
+	AuthToken        string
+	AuthCookieMaxAge int
+	AccessLog        string
+	AccessLogMaxSize int
+	AccessLogMaxBack int
+	AccessLogMaxAge  int
 }
 
 func Parse() *Config {
 	c := &Config{}
 	flag.IntVar(&c.Port, "port", 9080, "Listen port")
 	flag.IntVar(&c.Port, "p", 9080, "Listen port (shorthand)")
+	flag.StringVar(&c.Listen, "listen", "127.0.0.1", "Bind address (use 0.0.0.0 for remote access)")
 	flag.StringVar(&c.Theme, "theme", "github", "Default CSS theme")
 	flag.StringVar(&c.PlantUMLServer, "plantuml-server", "https://www.plantuml.com/plantuml", "PlantUML server URL")
-	flag.BoolVar(&c.AllowPrivateNetwork, "allow-private-network", false, "Allow fetching from private/internal IP addresses")
-	flag.BoolVar(&c.Verbose, "verbose", false, "Enable access logging")
-	flag.BoolVar(&c.Verbose, "v", false, "Enable access logging (shorthand)")
+	flag.BoolVar(&c.Verbose, "verbose", false, "Enable debug logging")
+	flag.BoolVar(&c.Verbose, "v", false, "Enable debug logging (shorthand)")
+	flag.StringVar(&c.AuthToken, "auth-token", "", "Authentication token (required in remote mode)")
+	flag.IntVar(&c.AuthCookieMaxAge, "auth-cookie-max-age", 30, "Authentication cookie max age in days")
+	flag.StringVar(&c.AccessLog, "access-log", "", "Access log file path")
+	flag.IntVar(&c.AccessLogMaxSize, "access-log-max-size", 100, "Access log max size in MB before rotation")
+	flag.IntVar(&c.AccessLogMaxBack, "access-log-max-backups", 3, "Max number of old access log files to retain")
+	flag.IntVar(&c.AccessLogMaxAge, "access-log-max-age", 28, "Max number of days to retain old access log files")
 	flag.Parse()
 	return c
+}
+
+// IsRemoteMode returns true when the server is configured to accept
+// connections from outside localhost.
+func (c *Config) IsRemoteMode() bool {
+	return c.Listen != "127.0.0.1" && c.Listen != "localhost"
+}
+
+// Validate checks the configuration for consistency.
+// Returns an error if the configuration is invalid.
+func (c *Config) Validate() error {
+	if c.IsRemoteMode() && c.AuthToken == "" {
+		return fmt.Errorf("--auth-token is required when --listen is not localhost (remote mode)")
+	}
+	return nil
 }

--- a/internal/handler/login.go
+++ b/internal/handler/login.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/patakuti/markdown-proxy/internal/config"
+)
+
+// CookieName is the name of the authentication cookie.
+const CookieName = "mdproxy_token"
+
+type LoginHandler struct {
+	cfg *config.Config
+}
+
+func NewLoginHandler(cfg *config.Config) *LoginHandler {
+	return &LoginHandler{cfg: cfg}
+}
+
+func (h *LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.showForm(w, "")
+	case http.MethodPost:
+		h.handleLogin(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h *LoginHandler) showForm(w http.ResponseWriter, errMsg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+
+	errorHTML := ""
+	if errMsg != "" {
+		errorHTML = `<p class="error">` + errMsg + `</p>`
+	}
+
+	w.Write([]byte(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Login - markdown-proxy</title>
+<style>
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    max-width: 400px;
+    margin: 120px auto;
+    padding: 0 20px;
+    color: #24292e;
+    background: #fff;
+  }
+  h1 { text-align: center; font-size: 1.8em; margin-bottom: 0.5em; }
+  .subtitle { text-align: center; color: #586069; margin-bottom: 2em; }
+  form { display: flex; flex-direction: column; gap: 12px; }
+  input[type="password"] {
+    padding: 10px 14px;
+    font-size: 16px;
+    border: 1px solid #d1d5da;
+    border-radius: 6px;
+    outline: none;
+  }
+  input[type="password"]:focus { border-color: #0366d6; box-shadow: 0 0 0 3px rgba(3,102,214,0.3); }
+  button {
+    padding: 10px 20px;
+    font-size: 16px;
+    background: #0366d6;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  button:hover { background: #0256b9; }
+  .error { color: #d73a49; text-align: center; margin: 0; }
+</style>
+</head>
+<body>
+<h1>markdown-proxy</h1>
+<p class="subtitle">Enter your access token</p>
+` + errorHTML + `
+<form method="POST" action="/_login">
+  <input type="password" name="token" placeholder="Access token" autofocus required>
+  <button type="submit">Login</button>
+</form>
+</body>
+</html>`))
+}
+
+func (h *LoginHandler) handleLogin(w http.ResponseWriter, r *http.Request) {
+	token := r.FormValue("token")
+
+	if subtle.ConstantTimeCompare([]byte(token), []byte(h.cfg.AuthToken)) != 1 {
+		w.WriteHeader(http.StatusUnauthorized)
+		h.showForm(w, "Invalid token")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     CookieName,
+		Value:    token,
+		MaxAge:   h.cfg.AuthCookieMaxAge * 86400, // days to seconds
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Path:     "/",
+	})
+
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}

--- a/internal/handler/top.go
+++ b/internal/handler/top.go
@@ -1,17 +1,20 @@
 package handler
 
 import (
+	"html/template"
 	"net/http"
 
 	"github.com/patakuti/markdown-proxy/internal/config"
 )
 
 type TopHandler struct {
-	cfg *config.Config
+	cfg  *config.Config
+	tmpl *template.Template
 }
 
 func NewTopHandler(cfg *config.Config) *TopHandler {
-	return &TopHandler{cfg: cfg}
+	tmpl := template.Must(template.New("top").Parse(topPageTmpl))
+	return &TopHandler{cfg: cfg, tmpl: tmpl}
 }
 
 func (h *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -21,10 +24,12 @@ func (h *TopHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Write([]byte(topPageHTML))
+	h.tmpl.Execute(w, map[string]bool{
+		"RemoteMode": h.cfg.IsRemoteMode(),
+	})
 }
 
-const topPageHTML = `<!DOCTYPE html>
+const topPageTmpl = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -87,16 +92,26 @@ const topPageHTML = `<!DOCTYPE html>
 </head>
 <body>
 <h1>markdown-proxy</h1>
+{{if .RemoteMode}}
+<p class="subtitle">Enter a URL to view Markdown</p>
+<div class="input-group">
+  <input type="text" id="path-input" placeholder="https://example.com/doc.md" autofocus>
+  <button onclick="navigate()">Open</button>
+</div>
+{{else}}
 <p class="subtitle">Enter a file path or URL to view Markdown</p>
 <div class="input-group">
   <input type="text" id="path-input" placeholder="/path/to/file.md or https://example.com/doc.md" autofocus>
   <button onclick="navigate()">Open</button>
 </div>
+{{end}}
 <div class="history" id="history-section" style="display:none;">
   <h2>Recent files <button class="clear-btn" onclick="clearHistory()">(clear)</button></h2>
   <ul id="history-list"></ul>
 </div>
 <script>
+var remoteMode = {{.RemoteMode}};
+
 function navigate() {
   var input = document.getElementById('path-input').value.trim();
   if (!input) return;
@@ -105,10 +120,15 @@ function navigate() {
     url = '/http/' + input.substring(7);
   } else if (input.startsWith('https://')) {
     url = '/https/' + input.substring(8);
-  } else if (input.startsWith('/') || input.startsWith('~') || /^[A-Za-z]:\\/.test(input)) {
-    url = '/local' + (input.startsWith('/') ? '' : '/') + input;
+  } else if (!remoteMode) {
+    if (input.startsWith('/') || input.startsWith('~') || /^[A-Za-z]:\\/.test(input)) {
+      url = '/local' + (input.startsWith('/') ? '' : '/') + input;
+    } else {
+      url = '/local/' + input;
+    }
   } else {
-    url = '/local/' + input;
+    // In remote mode, assume https if no scheme given
+    url = '/https/' + input;
   }
   saveHistory(input, url);
   window.location.href = url;
@@ -138,6 +158,9 @@ function clearHistory() {
 
 function renderHistory() {
   var history = getHistory();
+  if (remoteMode) {
+    history = history.filter(function(h) { return !h.url.startsWith('/local'); });
+  }
   var section = document.getElementById('history-section');
   var list = document.getElementById('history-list');
   if (history.length === 0) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,45 +1,90 @@
 package server
 
 import (
+	"crypto/subtle"
 	"fmt"
+	"io"
 	"log"
+	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/patakuti/markdown-proxy/internal/config"
 	"github.com/patakuti/markdown-proxy/internal/handler"
 	"github.com/patakuti/markdown-proxy/internal/network"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 func Run(cfg *config.Config) error {
 	mux := http.NewServeMux()
 
-	client := network.NewSafeClient(cfg.AllowPrivateNetwork)
+	// In local mode, allow private network access (user is local).
+	// In remote mode, block private network access (SSRF prevention).
+	client := network.NewSafeClient(!cfg.IsRemoteMode())
 
 	topHandler := handler.NewTopHandler(cfg)
-	localHandler := handler.NewLocalHandler(cfg)
 	remoteHandler := handler.NewRemoteHandler(cfg, client)
-	sseHandler := handler.NewSSEHandler()
 
 	mux.HandleFunc("/", topHandler.ServeHTTP)
-	mux.HandleFunc("/local/", localHandler.ServeHTTP)
 	mux.HandleFunc("/http/", remoteHandler.ServeHTTP)
 	mux.HandleFunc("/https/", remoteHandler.ServeHTTP)
-	mux.HandleFunc("/_sse", sseHandler.ServeHTTP)
 
-	var h http.Handler = mux
-	if cfg.Verbose {
-		h = loggingMiddleware(mux)
+	if cfg.IsRemoteMode() {
+		// In remote mode, block local file access and SSE
+		forbidden := func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Local file access is not available in remote mode", http.StatusForbidden)
+		}
+		mux.HandleFunc("/local/", forbidden)
+		mux.HandleFunc("/_sse", forbidden)
+
+		// Add login page handler
+		loginHandler := handler.NewLoginHandler(cfg)
+		mux.HandleFunc("/_login", loginHandler.ServeHTTP)
+	} else {
+		// In local mode, enable local file access and SSE
+		localHandler := handler.NewLocalHandler(cfg)
+		sseHandler := handler.NewSSEHandler()
+		mux.HandleFunc("/local/", localHandler.ServeHTTP)
+		mux.HandleFunc("/_sse", sseHandler.ServeHTTP)
 	}
 
-	addr := fmt.Sprintf("127.0.0.1:%d", cfg.Port)
-	log.Printf("Starting markdown-proxy on %s", addr)
+	// Build middleware chain (applied in reverse order)
+	// Request flow: verbose -> accessLog -> auth -> mux
+	var h http.Handler = mux
+
+	if cfg.AuthToken != "" {
+		h = authMiddleware(h, cfg.AuthToken)
+	}
+
+	if w := newAccessLogWriter(cfg); w != nil {
+		h = accessLogMiddleware(h, w)
+	}
+
+	if cfg.Verbose {
+		h = verboseMiddleware(h)
+	}
+
+	addr := fmt.Sprintf("%s:%d", cfg.Listen, cfg.Port)
+
+	if cfg.IsRemoteMode() {
+		log.Printf("WARNING: Starting markdown-proxy in REMOTE mode on %s", addr)
+		log.Printf("  Local file access is disabled")
+		log.Printf("  Authentication is enabled")
+	} else {
+		log.Printf("Starting markdown-proxy on %s", addr)
+	}
+
 	return http.ListenAndServe(addr, h)
 }
 
+// responseWriter wraps http.ResponseWriter to capture status code and
+// response size for logging.
 type responseWriter struct {
 	http.ResponseWriter
 	statusCode int
+	size       int
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
@@ -47,11 +92,79 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func loggingMiddleware(next http.Handler) http.Handler {
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	n, err := rw.ResponseWriter.Write(b)
+	rw.size += n
+	return n, err
+}
+
+// verboseMiddleware logs requests to stderr for debugging (--verbose).
+func verboseMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		next.ServeHTTP(rw, r)
 		log.Printf("%s %s %d %s", r.Method, r.URL.Path, rw.statusCode, time.Since(start))
+	})
+}
+
+// newAccessLogWriter returns the io.Writer for access log output.
+// Returns nil if access logging should be disabled.
+func newAccessLogWriter(cfg *config.Config) io.Writer {
+	if cfg.AccessLog != "" {
+		return &lumberjack.Logger{
+			Filename:   cfg.AccessLog,
+			MaxSize:    cfg.AccessLogMaxSize,
+			MaxBackups: cfg.AccessLogMaxBack,
+			MaxAge:     cfg.AccessLogMaxAge,
+		}
+	}
+	if cfg.IsRemoteMode() {
+		return os.Stdout
+	}
+	return nil
+}
+
+// authMiddleware checks for a valid authentication token in the request cookie.
+// Requests to /_login are allowed through without authentication.
+func authMiddleware(next http.Handler, token string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/_login") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		cookie, err := r.Cookie(handler.CookieName)
+		if err == nil && subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(token)) == 1 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		http.Redirect(w, r, "/_login", http.StatusSeeOther)
+	})
+}
+
+// accessLogMiddleware logs each request in a structured format.
+func accessLogMiddleware(next http.Handler, w io.Writer) http.Handler {
+	logger := log.New(w, "", 0)
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		wrapped := &responseWriter{ResponseWriter: rw, statusCode: http.StatusOK}
+		next.ServeHTTP(wrapped, r)
+
+		remoteIP, _, _ := net.SplitHostPort(r.RemoteAddr)
+		if remoteIP == "" {
+			remoteIP = r.RemoteAddr
+		}
+
+		logger.Printf("%s %s %s %s %d %d %s",
+			start.Format(time.RFC3339),
+			remoteIP,
+			r.Method,
+			r.URL.Path,
+			wrapped.statusCode,
+			wrapped.size,
+			time.Since(start).Round(time.Millisecond),
+		)
 	})
 }


### PR DESCRIPTION
## Summary
- Add `--listen` flag to support remote connections (default: `127.0.0.1` for backward compatibility)
- Add token-based authentication (`--auth-token`) with login page and HttpOnly cookie session
- Add access log middleware with automatic log rotation via lumberjack
- In remote mode: block local file access (`/local/`, `/_sse`), enforce authentication, block private network SSRF
- Remove `--allow-private-network` flag (now automatically controlled by operation mode)

## Test plan
- [x] Verify local mode works with all existing features (no regression)
- [x] Verify `--listen 0.0.0.0` without `--auth-token` fails with error
- [x] Verify remote mode redirects unauthenticated requests to `/_login`
- [x] Verify login page accepts correct token and sets cookie
- [x] Verify login page rejects incorrect token with 401
- [x] Verify `/local/` returns 403 in remote mode
- [x] Verify `/_sse` returns 403 in remote mode
- [x] Verify top page hides local path input in remote mode
- [x] Verify access log writes to file with rotation settings
- [x] Verify access log defaults to stdout in remote mode without `--access-log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)