### PR TITLE
Support path-based git credential matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An HTTP proxy server for viewing Markdown files in a browser. Supports both loca
   - PlantUML: server-side rendering from ```` ```plantuml ```` code blocks
 - GitHub/GitLab integration
   - Blob URL auto-conversion to raw URL
-  - Authentication via git credential helper (on 401/403 only)
+  - Authentication via git credential helper (supports path-based credential matching)
 - Multiple CSS themes (GitHub, Simple, Dark) with switching UI
 - Live reload for local files (auto-refreshes browser on file changes)
 - Directory listing for local files

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log"
 	"os/exec"
 	"strings"
 	"time"
@@ -12,12 +13,25 @@ import (
 // GetToken retrieves an authentication token for the given host using git credential helper.
 // Returns username and password/token, or empty strings if not available.
 // Uses a timeout to prevent hanging if the credential helper prompts interactively.
-func GetToken(host string) (username, password string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+// If path is non-empty, it searches git config for a path-based credential section
+// (e.g., [credential "https://github.com/org"]) and uses the matching path for lookup.
+func GetToken(host, path string) (username, password string, err error) {
+	// Find the matching credential path from git config
+	credPath := findCredentialPath(host, path)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "credential", "fill")
-	cmd.Stdin = strings.NewReader(fmt.Sprintf("protocol=https\nhost=%s\n\n", host))
+	args := []string{"credential", "fill"}
+	input := fmt.Sprintf("protocol=https\nhost=%s\n", host)
+	if credPath != "" {
+		// Enable useHttpPath so git matches [credential "https://host/path"] sections
+		args = []string{"-c", "credential.useHttpPath=true", "credential", "fill"}
+		input += fmt.Sprintf("path=%s\n", credPath)
+	}
+	input += "\n"
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Stdin = strings.NewReader(input)
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -38,4 +52,66 @@ func GetToken(host string) (username, password string, err error) {
 	}
 
 	return username, password, nil
+}
+
+// findCredentialPath searches git config for path-based credential sections
+// matching the given host and returns the best (longest) matching credential path.
+// e.g., for host="github.com" and remotePath="gn-nhc/azores/blob/main/README.md",
+// if [credential "https://github.com/gn-nhc"] exists, returns "gn-nhc".
+// Returns empty string if no path-specific credential config is found.
+func findCredentialPath(host, remotePath string) string {
+	if remotePath == "" {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "config", "--get-regexp", `^credential\.`)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+
+	prefix := "credential.https://" + host + "/"
+	knownSuffixes := []string{".helper", ".username", ".useHttpPath"}
+	bestMatch := ""
+
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		key, _, _ := strings.Cut(line, " ")
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		// key = "credential.https://github.com/gn-nhc.helper"
+		// remainder = "gn-nhc.helper"
+		remainder := strings.TrimPrefix(key, prefix)
+
+		// Extract the credential path by removing the known config key suffix
+		var credPath string
+		for _, suffix := range knownSuffixes {
+			if strings.HasSuffix(remainder, suffix) {
+				credPath = strings.TrimSuffix(remainder, suffix)
+				break
+			}
+		}
+		if credPath == "" {
+			continue
+		}
+
+		// Check if credPath matches remotePath (exact or prefix with path boundary)
+		if remotePath == credPath || strings.HasPrefix(remotePath, credPath+"/") {
+			if len(credPath) > len(bestMatch) {
+				bestMatch = credPath
+			}
+		}
+	}
+
+	if bestMatch != "" {
+		log.Printf("[credential] found matching credential path: %s (from config for https://%s/%s)", bestMatch, host, bestMatch)
+	}
+
+	return bestMatch
 }

--- a/internal/github/resolve.go
+++ b/internal/github/resolve.go
@@ -72,3 +72,13 @@ func HostFromPath(path string) string {
 	}
 	return path[:idx]
 }
+
+// PathFromPath extracts the path portion (after the host) from a URL path.
+// e.g., "github.com/user/repo/blob/main/file.md" → "user/repo/blob/main/file.md"
+func PathFromPath(path string) string {
+	idx := strings.Index(path, "/")
+	if idx < 0 {
+		return ""
+	}
+	return path[idx+1:]
+}

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -153,8 +153,9 @@ func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, strin
 	// not the resolved raw host (e.g. raw.githubusercontent.com)
 	if httpErr, ok := err.(*httpError); ok && (httpErr.StatusCode == 401 || httpErr.StatusCode == 403 || httpErr.StatusCode == 404) {
 		host := ghub.HostFromPath(remotePath)
-		log.Printf("Got %d for %s, trying git credential for host=%s", httpErr.StatusCode, remoteURL, host)
-		username, password, credErr := credential.GetToken(host)
+		credPath := ghub.PathFromPath(remotePath)
+		log.Printf("Got %d for %s, trying git credential for host=%s path=%s", httpErr.StatusCode, remoteURL, host, credPath)
+		username, password, credErr := credential.GetToken(host, credPath)
 		if credErr != nil {
 			log.Printf("Warning: git credential failed for %s: %v", host, credErr)
 			return nil, "", err // return original HTTP error


### PR DESCRIPTION
## Summary
- Add support for `.gitconfig` path-based credential sections (e.g., `[credential "https://github.com/org"]`)
- Parse git config to find matching credential paths via prefix matching, and pass the exact credential path with `useHttpPath=true` to `git credential fill`
- Add `PathFromPath` utility to extract the path portion after the host
- Increase credential timeout from 3s to 30s to support GUI credential managers (e.g., Windows Credential Manager via WSL)

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Tested with path-based credential config (`[credential "https://github.com/gn-nhc"]` with `gh auth git-credential`)
- [x] Tested with GUI credential manager (`git-credential-manager.exe` via WSL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)