### PR TITLE
Support self-hosted GitLab with custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ An HTTP proxy server for viewing Markdown files in a browser. Supports both loca
   - Mermaid: client-side rendering via mermaid.js from ```` ```mermaid ```` code blocks
   - PlantUML: server-side rendering from ```` ```plantuml ```` code blocks
 - GitHub/GitLab integration
-  - Blob URL auto-conversion to raw URL
+  - Blob URL auto-conversion to raw URL (supports self-hosted GitLab with custom domains)
   - Authentication via git credential helper (supports path-based credential matching)
+  - Redirect-based auth detection for self-hosted GitLab instances
 - Multiple CSS themes (GitHub, Simple, Dark) with switching UI
 - Live reload for local files (auto-refreshes browser on file changes)
 - Directory listing for local files

--- a/internal/github/resolve.go
+++ b/internal/github/resolve.go
@@ -11,8 +11,9 @@ var githubBlobRe = regexp.MustCompile(`^github\.com/([^/]+)/([^/]+)/blob/([^/]+)
 // GitHub repo root pattern: github.com/user/repo (with optional trailing slash)
 var githubRepoRe = regexp.MustCompile(`^github\.com/([^/]+)/([^/]+?)/?$`)
 
-// GitLab blob URL pattern: gitlab.com/user/repo/-/blob/<ref>/path
-var gitlabBlobRe = regexp.MustCompile(`^gitlab\.com/([^/]+)/([^/]+)/-/blob/([^/]+)/(.+)$`)
+// GitLab blob URL pattern: <host>/<project>/-/blob/<ref>/path
+// Matches any host with /-/blob/ (GitLab-specific URL structure), supporting subgroups.
+var gitlabBlobRe = regexp.MustCompile(`^([^/]+)/(.+?)/-/blob/([^/]+)/(.+)$`)
 
 // GitLab repo root pattern: gitlab.com/user/repo (with optional trailing slash)
 var gitlabRepoRe = regexp.MustCompile(`^gitlab\.com/([^/]+)/([^/]+?)/?$`)
@@ -28,10 +29,10 @@ func ResolveRawURL(path string) (string, bool) {
 		return rawURL, true
 	}
 
-	// GitLab: gitlab.com/user/repo/-/blob/<ref>/path → gitlab.com/user/repo/-/raw/<ref>/path
+	// GitLab: <host>/<project>/-/blob/<ref>/path → <host>/<project>/-/raw/<ref>/path
 	if m := gitlabBlobRe.FindStringSubmatch(path); m != nil {
-		user, repo, ref, filePath := m[1], m[2], m[3], m[4]
-		rawURL := "gitlab.com/" + user + "/" + repo + "/-/raw/" + ref + "/" + filePath
+		host, project, ref, filePath := m[1], m[2], m[3], m[4]
+		rawURL := host + "/" + project + "/-/raw/" + ref + "/" + filePath
 		return rawURL, true
 	}
 

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -141,17 +141,21 @@ func (h *RemoteHandler) renderResponse(w http.ResponseWriter, body []byte, conte
 }
 
 func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, string, error) {
-	// First attempt: without authentication
-	body, contentType, err := h.doFetch(remoteURL, "", "")
+	// First attempt: without authentication, do not follow redirects.
+	// Self-hosted GitLab redirects to login page (302) for unauthenticated access,
+	// and Go's http.Client follows redirects by default, returning 200 (login HTML).
+	// By disabling redirects, we get the 3xx status code and can trigger auth retry.
+	body, contentType, err := h.doFetch(remoteURL, "", "", false)
 	if err == nil {
 		return body, contentType, nil
 	}
 
-	// If 401/403/404, retry with git credential helper
+	// If 3xx/401/403/404, retry with git credential helper
 	// Note: GitHub returns 404 for private repos when unauthenticated
+	// Note: Self-hosted GitLab returns 302 redirect to login for unauthenticated access
 	// Use original remotePath host (e.g. github.com) for credential lookup,
 	// not the resolved raw host (e.g. raw.githubusercontent.com)
-	if httpErr, ok := err.(*httpError); ok && (httpErr.StatusCode == 401 || httpErr.StatusCode == 403 || httpErr.StatusCode == 404) {
+	if httpErr, ok := err.(*httpError); ok && (httpErr.StatusCode == 401 || httpErr.StatusCode == 403 || httpErr.StatusCode == 404 || (httpErr.StatusCode >= 300 && httpErr.StatusCode <= 399)) {
 		host := ghub.HostFromPath(remotePath)
 		credPath := ghub.PathFromPath(remotePath)
 		log.Printf("Got %d for %s, trying git credential for host=%s path=%s", httpErr.StatusCode, remoteURL, host, credPath)
@@ -165,7 +169,8 @@ func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, strin
 				username = "oauth2"
 			}
 			log.Printf("Retrying with credential (user=%s) for %s", username, remoteURL)
-			return h.doFetch(remoteURL, username, password)
+			// Authenticated retry follows redirects normally (for legitimate redirects)
+			return h.doFetch(remoteURL, username, password, true)
 		}
 		log.Printf("Warning: git credential returned empty password for %s", host)
 	}
@@ -173,7 +178,7 @@ func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, strin
 	return nil, "", err
 }
 
-func (h *RemoteHandler) doFetch(remoteURL, username, password string) ([]byte, string, error) {
+func (h *RemoteHandler) doFetch(remoteURL, username, password string, followRedirects bool) ([]byte, string, error) {
 	req, err := http.NewRequest("GET", remoteURL, nil)
 	if err != nil {
 		return nil, "", err
@@ -184,7 +189,19 @@ func (h *RemoteHandler) doFetch(remoteURL, username, password string) ([]byte, s
 		req.Header.Set("Authorization", "token "+password)
 	}
 
-	resp, err := h.client.Do(req)
+	client := h.client
+	if !followRedirects {
+		// Shallow copy the client and disable redirect following.
+		// This allows detecting 3xx responses (e.g., self-hosted GitLab
+		// redirecting to login page) as auth-required signals.
+		c := *h.client
+		c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		client = &c
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary
- Generalize GitLab blob URL pattern to detect `/-/blob/` path structure instead of hardcoded `gitlab.com`, enabling support for self-hosted GitLab instances with custom domains
- Detect 3xx redirects on unauthenticated requests and trigger auth retry, fixing authentication for self-hosted GitLab that redirects to login page (302) instead of returning 401/403
- Disable redirect following for initial unauthenticated fetch; re-enable for authenticated retry to handle legitimate redirects

## Test plan
- [x] `go build ./...` passes
- [x] Access a file on self-hosted GitLab (`gitlab.example.com/group/repo/-/blob/main/README.md`) and verify blob→raw URL conversion works
- [x] Verify authentication triggers correctly when self-hosted GitLab returns 302 redirect
- [x] Verify `gitlab.com` blob URLs still work as before
- [x] Verify `github.com` blob URLs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)