### PR TITLE
Disable PlantUML server by default for secure-by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ markdown-proxy solves these problems by rendering Markdown files — including P
 - Code block rendering
   - SVG: inline SVG rendering from ```` ```svg ```` code blocks
   - Mermaid: client-side rendering via mermaid.js from ```` ```mermaid ```` code blocks
-  - PlantUML: server-side rendering from ```` ```plantuml ```` code blocks
+  - PlantUML: server-side rendering from ```` ```plantuml ```` code blocks (requires `--plantuml-server`)
 - GitHub/GitLab integration
   - Blob URL auto-conversion to raw URL (supports self-hosted GitLab with custom domains)
   - Authentication via git credential helper (supports path-based credential matching)
@@ -59,7 +59,7 @@ markdown-proxy [options]
 | `--port`, `-p` | Listen port | `9080` |
 | `--listen` | Bind address (`127.0.0.1` for local, `0.0.0.0` for remote) | `127.0.0.1` |
 | `--theme` | Default CSS theme (`github`, `simple`, `dark`) | `github` |
-| `--plantuml-server` | PlantUML server URL | `https://www.plantuml.com/plantuml` |
+| `--plantuml-server` | PlantUML server URL | (disabled) |
 | `--auth-token` | Authentication token (required in remote mode) | |
 | `--auth-cookie-max-age` | Authentication cookie max age in days | `30` |
 | `--access-log` | Access log file path | |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,7 +25,7 @@ func Parse() *Config {
 	flag.IntVar(&c.Port, "p", 9080, "Listen port (shorthand)")
 	flag.StringVar(&c.Listen, "listen", "127.0.0.1", "Bind address (use 0.0.0.0 for remote access)")
 	flag.StringVar(&c.Theme, "theme", "github", "Default CSS theme")
-	flag.StringVar(&c.PlantUMLServer, "plantuml-server", "https://www.plantuml.com/plantuml", "PlantUML server URL")
+	flag.StringVar(&c.PlantUMLServer, "plantuml-server", "", "PlantUML server URL (disabled by default; e.g. https://www.plantuml.com/plantuml)")
 	flag.BoolVar(&c.Verbose, "verbose", false, "Enable debug logging")
 	flag.BoolVar(&c.Verbose, "v", false, "Enable debug logging (shorthand)")
 	flag.StringVar(&c.AuthToken, "auth-token", "", "Authentication token (required in remote mode)")


### PR DESCRIPTION
## Summary

- Change `--plantuml-server` default from `https://www.plantuml.com/plantuml` to empty string (disabled)
- PlantUML code blocks are now rendered as plain code blocks by default, preventing diagram content from being sent to an external server
- Users who want PlantUML rendering must explicitly specify `--plantuml-server`

## Test plan

- [x] `go build ./...` passes
- [x] Without `--plantuml-server`: PlantUML code blocks remain as code blocks (not rendered)
- [x] With `--plantuml-server https://www.plantuml.com/plantuml`: PlantUML diagrams render as images

🤖 Generated with [Claude Code](https://claude.com/claude-code)