### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go mod download
+
+      - run: go vet ./...
+
+      - run: go test ./...
+
+      - run: make build
+
+      - run: make linux
+
+      - run: make windows


### PR DESCRIPTION
## Summary
- Add minimal CI workflow (`.github/workflows/ci.yml`) that runs on push to main and PRs targeting main
- Runs `go vet`, `go test`, and cross-platform build verification (`make build`, `make linux`, `make windows`)
- Go version is read from `go.mod` (1.22) via `actions/setup-go@v5`

## Test plan
- [x] `go vet ./...` passes locally
- [x] `go test ./...` passes locally
- [x] `make build`, `make linux`, `make windows` pass locally
- [x] Verify GitHub Actions workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)