### PR TITLE
Improve code block highlighting: font size, borders, and dark theme colors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module github.com/patakuti/markdown-proxy
 go 1.22.2
 
 require (
-	github.com/alecthomas/chroma/v2 v2.2.0 // indirect
+	github.com/alecthomas/chroma/v2 v2.2.0
+	github.com/fsnotify/fsnotify v1.9.0
+	github.com/litao91/goldmark-mathjax v0.0.0-20210217064022-a43cf739a50f
+	github.com/yuin/goldmark v1.7.16
+	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
+)
+
+require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/litao91/goldmark-mathjax v0.0.0-20210217064022-a43cf739a50f // indirect
-	github.com/yuin/goldmark v1.7.16 // indirect
-	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc // indirect
 	golang.org/x/sys v0.13.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/alecthomas/chroma/v2 v2.2.0 h1:Aten8jfQwUqEdadVFFjNyjx7HTexhKP0XuqBG67mRDY=
 github.com/alecthomas/chroma/v2 v2.2.0/go.mod h1:vf4zrexSH54oEjJ7EdB65tGNHmH3pGZmVkgTP5RHvAs=
+github.com/alecthomas/repr v0.0.0-20220113201626-b1b626ac65ae h1:zzGwJfFlFGD94CyyYwCJeSuD32Gj9GTaSi5y9hoVzdY=
 github.com/alecthomas/repr v0.0.0-20220113201626-b1b626ac65ae/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
@@ -10,9 +12,11 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/litao91/goldmark-mathjax v0.0.0-20210217064022-a43cf739a50f h1:plCPYXRXDCO57qjqegCzaVf1t6aSbgCMD+zfz18POfs=
 github.com/litao91/goldmark-mathjax v0.0.0-20210217064022-a43cf739a50f/go.mod h1:leg+HM7jUS84JYuY120zmU68R6+UeU6uZ/KAW7cViKE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.15/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -25,4 +29,5 @@ golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/markdown/convert.go
+++ b/internal/markdown/convert.go
@@ -3,6 +3,7 @@ package markdown
 import (
 	"bytes"
 
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
 	mathjax "github.com/litao91/goldmark-mathjax"
 	"github.com/yuin/goldmark"
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
@@ -19,6 +20,9 @@ func init() {
 			extension.GFM,
 			highlighting.NewHighlighting(
 				highlighting.WithStyle("github"),
+				highlighting.WithFormatOptions(
+					chromahtml.WithClasses(true),
+				),
 			),
 			mathjax.MathJax,
 		),

--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -62,9 +62,10 @@ const githubCSS = `
   background: #f6f8fa;
   padding: 16px;
   border-radius: 6px;
+  border: 1px solid #e1e4e8;
   overflow: auto;
 }
-.theme-github .markdown-body pre code { background: none; padding: 0; }
+.theme-github .markdown-body pre code { background: none; padding: 0; font-size: 100%; }
 .theme-github .markdown-body blockquote {
   color: #6a737d;
   border-left: .25em solid #dfe2e5;
@@ -91,9 +92,10 @@ const simpleCSS = `
   background: #f0f0f0;
   padding: 14px;
   border-radius: 4px;
+  border: 1px solid #ddd;
   overflow: auto;
 }
-.theme-simple .markdown-body pre code { background: none; padding: 0; }
+.theme-simple .markdown-body pre code { background: none; padding: 0; font-size: 100%; }
 .theme-simple .markdown-body blockquote {
   color: #666;
   border-left: 3px solid #ccc;
@@ -123,9 +125,10 @@ const darkCSS = `
   background: #161b22;
   padding: 16px;
   border-radius: 6px;
+  border: 1px solid #30363d;
   overflow: auto;
 }
-.theme-dark .markdown-body pre code { background: none; padding: 0; }
+.theme-dark .markdown-body pre code { background: none; padding: 0; font-size: 100%; }
 .theme-dark .markdown-body blockquote {
   color: #8b949e;
   border-left: .25em solid #30363d;

--- a/internal/template/highlight.go
+++ b/internal/template/highlight.go
@@ -1,0 +1,66 @@
+package template
+
+import (
+	"bytes"
+	"strings"
+
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
+)
+
+// highlightCSS holds the combined syntax highlight CSS for all themes.
+var highlightCSS string
+
+func init() {
+	var buf strings.Builder
+
+	// GitHub/Simple themes: use "github" chroma style
+	githubSyntax := generateSyntaxCSS("github")
+	buf.WriteString(scopeCSS(githubSyntax, ".theme-github"))
+	buf.WriteString("\n")
+	buf.WriteString(scopeCSS(githubSyntax, ".theme-simple"))
+	buf.WriteString("\n")
+
+	// Dark theme: use "monokai" chroma style
+	monokaiSyntax := generateSyntaxCSS("monokai")
+	buf.WriteString(scopeCSS(monokaiSyntax, ".theme-dark"))
+	buf.WriteString("\n")
+
+	highlightCSS = buf.String()
+}
+
+// generateSyntaxCSS generates CSS from a named chroma style.
+func generateSyntaxCSS(styleName string) string {
+	style := styles.Get(styleName)
+	formatter := chromahtml.New(chromahtml.WithClasses(true))
+
+	var buf bytes.Buffer
+	if err := formatter.WriteCSS(&buf, style); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+// scopeCSS prefixes CSS selectors with a theme class scope.
+// Each line containing a CSS selector (starting with ".") gets the scope prepended.
+func scopeCSS(css, scope string) string {
+	var result strings.Builder
+	for _, line := range strings.Split(css, "\n") {
+		if line == "" {
+			result.WriteString("\n")
+			continue
+		}
+		// Find the first "." which marks the CSS selector
+		idx := strings.Index(line, ".")
+		if idx >= 0 && strings.Contains(line, "{") {
+			result.WriteString(line[:idx])
+			result.WriteString(scope)
+			result.WriteString(" ")
+			result.WriteString(line[idx:])
+		} else {
+			result.WriteString(line)
+		}
+		result.WriteString("\n")
+	}
+	return result.String()
+}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -56,7 +56,14 @@ func (w *byteWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-const markdownPageTpl = `<!DOCTYPE html>
+// markdownPageTpl is built at init time to include runtime-generated highlight CSS.
+var markdownPageTpl string
+
+func init() {
+	markdownPageTpl = markdownPageTplHead + "<style>" + highlightCSS + "</style>\n" + markdownPageTplTail
+}
+
+const markdownPageTplHead = `<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="UTF-8">
@@ -66,7 +73,9 @@ const markdownPageTpl = `<!DOCTYPE html>
 <style>` + simpleCSS + `</style>
 <style>` + darkCSS + `</style>
 <style>` + commonCSS + `</style>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+`
+
+const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Switch syntax highlighting from inline styles to CSS class-based output using Chroma
- Apply theme-appropriate Chroma styles: "github" for GitHub/Simple themes, "monokai" for Dark theme
- Fix code block font size by adding `font-size: 100%` to `pre code` (inline code keeps `85%`)
- Add visible borders to `pre` elements in all themes (GitHub: `#e1e4e8`, Simple: `#ddd`, Dark: `#30363d`)

## Test plan
- [x] Verify code blocks render with readable font size (same as body text) in all themes
- [x] Verify code block borders are visible in GitHub and Simple themes
- [x] Verify Dark theme syntax highlighting uses monokai color scheme
- [x] Verify theme switching correctly applies different syntax highlight colors
- [x] Verify inline code still renders at 85% font size

🤖 Generated with [Claude Code](https://claude.com/claude-code)