### PR TITLE
Fix authentication for self-hosted GitLab with custom domain

### DIFF
--- a/internal/github/resolve.go
+++ b/internal/github/resolve.go
@@ -29,11 +29,14 @@ func ResolveRawURL(path string) (string, bool) {
 		return rawURL, true
 	}
 
-	// GitLab: <host>/<project>/-/blob/<ref>/path → <host>/<project>/-/raw/<ref>/path
+	// GitLab: <host>/<project>/-/blob/<ref>/path → <host>/api/v4/projects/<encoded_project>/repository/files/<encoded_file>/raw?ref=<ref>
+	// Uses the GitLab API endpoint instead of /-/raw/ because the web endpoint does not
+	// accept Bearer token authentication on some self-hosted instances.
 	if m := gitlabBlobRe.FindStringSubmatch(path); m != nil {
 		host, project, ref, filePath := m[1], m[2], m[3], m[4]
-		rawURL := host + "/" + project + "/-/raw/" + ref + "/" + filePath
-		return rawURL, true
+		encodedProject := strings.ReplaceAll(project, "/", "%2F")
+		encodedFilePath := strings.ReplaceAll(filePath, "/", "%2F")
+		return host + "/api/v4/projects/" + encodedProject + "/repository/files/" + encodedFilePath + "/raw?ref=" + ref, true
 	}
 
 	return path, false
@@ -52,12 +55,13 @@ func ResolveRepoRootURLs(path string) []string {
 		}
 	}
 
-	// GitLab: gitlab.com/user/repo → try main, then master
+	// GitLab: gitlab.com/user/repo → try main, then master (via API endpoint)
 	if m := gitlabRepoRe.FindStringSubmatch(path); m != nil {
 		user, repo := m[1], m[2]
+		encodedProject := user + "%2F" + repo
 		return []string{
-			"gitlab.com/" + user + "/" + repo + "/-/raw/main/README.md",
-			"gitlab.com/" + user + "/" + repo + "/-/raw/master/README.md",
+			"gitlab.com/api/v4/projects/" + encodedProject + "/repository/files/README.md/raw?ref=main",
+			"gitlab.com/api/v4/projects/" + encodedProject + "/repository/files/README.md/raw?ref=master",
 		}
 	}
 

--- a/internal/github/resolve_test.go
+++ b/internal/github/resolve_test.go
@@ -40,19 +40,19 @@ func TestResolveRawURL(t *testing.T) {
 		{
 			name:   "GitLab basic blob URL",
 			path:   "gitlab.com/user/repo/-/blob/main/README.md",
-			want:   "gitlab.com/user/repo/-/raw/main/README.md",
+			want:   "gitlab.com/api/v4/projects/user%2Frepo/repository/files/README.md/raw?ref=main",
 			wantOK: true,
 		},
 		{
 			name:   "GitLab subgroup",
 			path:   "gitlab.com/group/subgroup/repo/-/blob/main/file.md",
-			want:   "gitlab.com/group/subgroup/repo/-/raw/main/file.md",
+			want:   "gitlab.com/api/v4/projects/group%2Fsubgroup%2Frepo/repository/files/file.md/raw?ref=main",
 			wantOK: true,
 		},
 		{
 			name:   "GitLab custom domain",
 			path:   "gitlab.example.com/team/project/-/blob/develop/docs/api.md",
-			want:   "gitlab.example.com/team/project/-/raw/develop/docs/api.md",
+			want:   "gitlab.example.com/api/v4/projects/team%2Fproject/repository/files/docs%2Fapi.md/raw?ref=develop",
 			wantOK: true,
 		},
 		// Non-matching paths
@@ -121,16 +121,16 @@ func TestResolveRepoRootURLs(t *testing.T) {
 			name: "GitLab repo root",
 			path: "gitlab.com/user/repo",
 			want: []string{
-				"gitlab.com/user/repo/-/raw/main/README.md",
-				"gitlab.com/user/repo/-/raw/master/README.md",
+				"gitlab.com/api/v4/projects/user%2Frepo/repository/files/README.md/raw?ref=main",
+				"gitlab.com/api/v4/projects/user%2Frepo/repository/files/README.md/raw?ref=master",
 			},
 		},
 		{
 			name: "GitLab repo root with trailing slash",
 			path: "gitlab.com/user/repo/",
 			want: []string{
-				"gitlab.com/user/repo/-/raw/main/README.md",
-				"gitlab.com/user/repo/-/raw/master/README.md",
+				"gitlab.com/api/v4/projects/user%2Frepo/repository/files/README.md/raw?ref=main",
+				"gitlab.com/api/v4/projects/user%2Frepo/repository/files/README.md/raw?ref=master",
 			},
 		},
 		{

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -105,7 +105,9 @@ func (h *RemoteHandler) renderMarkdownResponse(w http.ResponseWriter, body []byt
 
 // renderResponse renders body based on file extension.
 func (h *RemoteHandler) renderResponse(w http.ResponseWriter, body []byte, contentType, fetchPath, remotePath, scheme string) {
-	ext := strings.ToLower(path.Ext(fetchPath))
+	// Use remotePath (original blob URL) for extension detection, not fetchPath.
+	// fetchPath may be a GitLab API URL (ending in /raw?ref=...) which has no file extension.
+	ext := strings.ToLower(path.Ext(remotePath))
 
 	// Non-markdown files: pass through
 	if ext != ".md" && ext != ".markdown" {
@@ -185,8 +187,9 @@ func (h *RemoteHandler) doFetch(remoteURL, username, password string, followRedi
 	}
 
 	if password != "" {
-		// GitHub/GitLab tokens work with "token <PAT>" authorization header
-		req.Header.Set("Authorization", "token "+password)
+		// Use "Bearer" format for OAuth2 tokens (glab auth login) and PATs.
+		// GitHub also accepts "Bearer" as an alias for "token".
+		req.Header.Set("Authorization", "Bearer "+password)
 	}
 
 	client := h.client


### PR DESCRIPTION
## Summary

- Change Authorization header from "token" to "Bearer" format for OAuth2 token compatibility (GitHub also accepts Bearer)
- Switch GitLab URL resolution from `/-/raw/` to the API endpoint (`/api/v4/projects/.../repository/files/.../raw`) which reliably accepts Bearer token authentication on all instances
- Fix file extension detection to use original blob URL instead of resolved API URL (which has no file extension)
- Update `ResolveRepoRootURLs` to use GitLab API endpoint consistently

## Test plan

- [x] All existing tests pass with updated expectations
- [x] Build succeeds
- [x] Verify authentication works with self-hosted GitLab custom domain
- [x] Verify GitHub authentication still works (Bearer is accepted)
- [x] Verify gitlab.com repo root access works with API endpoint

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)