### PR TITLE
Fix single-line display math block preprocessing

### DIFF
--- a/internal/markdown/convert.go
+++ b/internal/markdown/convert.go
@@ -38,6 +38,9 @@ func init() {
 // Convert converts Markdown source to HTML.
 // plantumlServer is the PlantUML server URL for code block conversion.
 func Convert(source []byte, plantumlServer string) ([]byte, error) {
+	// Pre-process: expand single-line $$...$$ to multi-line for goldmark-mathjax
+	source = PreprocessMathBlocks(source)
+
 	// Pre-process: replace svg, mermaid, plantuml code blocks with raw HTML
 	source = PreprocessCodeBlocks(source, plantumlServer)
 

--- a/internal/markdown/mathblock.go
+++ b/internal/markdown/mathblock.go
@@ -1,0 +1,60 @@
+package markdown
+
+import (
+	"bytes"
+	"regexp"
+)
+
+// singleLineMathRe matches a line containing only $$<content>$$ (with optional surrounding whitespace).
+// This does NOT match inline usage like "text $$a=b$$ text" because the line must start with $$.
+var singleLineMathRe = regexp.MustCompile(`^(\s*)\$\$(.+)\$\$\s*$`)
+
+// fenceStartRe matches the start of a fenced code block (``` or ~~~).
+var fenceStartRe = regexp.MustCompile(`^(\x60{3,}|~{3,})`)
+
+// PreprocessMathBlocks converts single-line display math ($$...$$ on one line)
+// to multi-line format ($$\n...\n$$) so that goldmark-mathjax can parse it correctly.
+// Fenced code blocks are skipped to avoid modifying code content.
+func PreprocessMathBlocks(source []byte) []byte {
+	lines := bytes.Split(source, []byte("\n"))
+	var result [][]byte
+	var inFence bool
+	var fenceMarker []byte
+
+	for _, line := range lines {
+		if inFence {
+			// Check if this line closes the fence
+			if m := fenceStartRe.FindSubmatch(line); m != nil {
+				marker := m[1]
+				if marker[0] == fenceMarker[0] && len(marker) >= len(fenceMarker) {
+					inFence = false
+					fenceMarker = nil
+				}
+			}
+			result = append(result, line)
+			continue
+		}
+
+		// Check if this line opens a fenced code block
+		if m := fenceStartRe.FindSubmatch(line); m != nil {
+			inFence = true
+			fenceMarker = m[1]
+			result = append(result, line)
+			continue
+		}
+
+		// Check for single-line $$...$$ pattern
+		if sm := singleLineMathRe.FindSubmatch(line); sm != nil {
+			indent := sm[1]
+			content := sm[2]
+			result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
+			result = append(result, append(append([]byte{}, indent...), content...))
+			result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
+			continue
+		}
+
+		result = append(result, line)
+	}
+
+	return bytes.Join(result, []byte("\n"))
+}

--- a/internal/markdown/mathblock_test.go
+++ b/internal/markdown/mathblock_test.go
@@ -1,0 +1,103 @@
+package markdown
+
+import (
+	"testing"
+)
+
+func TestPreprocessMathBlocks(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "single-line display math",
+			input:  "$$a=b$$",
+			expect: "$$\na=b\n$$",
+		},
+		{
+			name:   "single-line with spaces around content",
+			input:  "$$ a = b $$",
+			expect: "$$\n a = b \n$$",
+		},
+		{
+			name:   "single-line with leading whitespace",
+			input:  "  $$a=b$$",
+			expect: "  $$\n  a=b\n  $$",
+		},
+		{
+			name:   "single-line with trailing whitespace",
+			input:  "$$a=b$$  ",
+			expect: "$$\na=b\n$$",
+		},
+		{
+			name:   "multi-line display math unchanged",
+			input:  "$$\na=b\n$$",
+			expect: "$$\na=b\n$$",
+		},
+		{
+			name:   "inline math unchanged",
+			input:  "text $a=b$ text",
+			expect: "text $a=b$ text",
+		},
+		{
+			name:   "inline display math unchanged (text around $$)",
+			input:  "text $$a=b$$ text",
+			expect: "text $$a=b$$ text",
+		},
+		{
+			name:   "inside fenced code block backticks",
+			input:  "```\n$$a=b$$\n```",
+			expect: "```\n$$a=b$$\n```",
+		},
+		{
+			name:   "inside fenced code block tildes",
+			input:  "~~~\n$$a=b$$\n~~~",
+			expect: "~~~\n$$a=b$$\n~~~",
+		},
+		{
+			name:   "inside fenced code block with language",
+			input:  "```math\n$$a=b$$\n```",
+			expect: "```math\n$$a=b$$\n```",
+		},
+		{
+			name:   "after fenced code block",
+			input:  "```\ncode\n```\n$$a=b$$",
+			expect: "```\ncode\n```\n$$\na=b\n$$",
+		},
+		{
+			name:   "multiple math blocks",
+			input:  "$$x=1$$\ntext\n$$y=2$$",
+			expect: "$$\nx=1\n$$\ntext\n$$\ny=2\n$$",
+		},
+		{
+			name:   "empty content between $$",
+			input:  "$$$$",
+			expect: "$$$$",
+		},
+		{
+			name:   "complex LaTeX expression",
+			input:  `$$\frac{a}{b} + \sqrt{c}$$`,
+			expect: "$$\n\\frac{a}{b} + \\sqrt{c}\n$$",
+		},
+		{
+			name:   "mixed content",
+			input:  "# Title\n\n$$E=mc^2$$\n\nSome text\n\n$$\nF=ma\n$$",
+			expect: "# Title\n\n$$\nE=mc^2\n$$\n\nSome text\n\n$$\nF=ma\n$$",
+		},
+		{
+			name:   "nested fenced code blocks (longer fence closes)",
+			input:  "````\n```\n$$a=b$$\n```\n````\n$$x=1$$",
+			expect: "````\n```\n$$a=b$$\n```\n````\n$$\nx=1\n$$",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(PreprocessMathBlocks([]byte(tt.input)))
+			if got != tt.expect {
+				t.Errorf("PreprocessMathBlocks()\ngot:    %q\nexpect: %q", got, tt.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `PreprocessMathBlocks` to expand single-line `$$...$$` to multi-line format before goldmark processing
- Fenced code blocks are skipped to avoid modifying code content
- 16 test cases covering basic conversion, inline exclusion, code block skipping, nested fences, etc.

Closes #17

## Test plan

- [x] `go test ./internal/markdown/...` passes
- [x] `go build ./cmd/markdown-proxy` succeeds
- [x] Manual verification: serve a Markdown file containing `$$a=b$$` and confirm it renders correctly in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)