### PR TITLE
Fix remote files with URL-encoded Japanese characters on GitLab

### DIFF
--- a/internal/github/resolve_test.go
+++ b/internal/github/resolve_test.go
@@ -55,6 +55,25 @@ func TestResolveRawURL(t *testing.T) {
 			want:   "gitlab.example.com/api/v4/projects/team%2Fproject/repository/files/docs%2Fapi.md/raw?ref=develop",
 			wantOK: true,
 		},
+		// URL-encoded Japanese characters
+		{
+			name:   "GitHub blob URL with encoded Japanese filename",
+			path:   "github.com/user/repo/blob/main/docs/%E6%97%A5%E6%9C%AC%E8%AA%9E.md",
+			want:   "raw.githubusercontent.com/user/repo/main/docs/%E6%97%A5%E6%9C%AC%E8%AA%9E.md",
+			wantOK: true,
+		},
+		{
+			name:   "GitLab blob URL with encoded Japanese filename",
+			path:   "gitlab.com/user/repo/-/blob/main/docs/%E6%97%A5%E6%9C%AC%E8%AA%9E.md",
+			want:   "gitlab.com/api/v4/projects/user%2Frepo/repository/files/docs%2F%E6%97%A5%E6%9C%AC%E8%AA%9E.md/raw?ref=main",
+			wantOK: true,
+		},
+		{
+			name:   "GitLab blob URL with encoded Japanese in nested path",
+			path:   "gitlab.example.com/group/project/-/blob/main/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88/%E6%97%A5%E6%9C%AC%E8%AA%9E.md",
+			want:   "gitlab.example.com/api/v4/projects/group%2Fproject/repository/files/%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88%2F%E6%97%A5%E6%9C%AC%E8%AA%9E.md/raw?ref=main",
+			wantOK: true,
+		},
 		// Non-matching paths
 		{
 			name:   "GitHub tree URL (not blob)",

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -28,12 +28,15 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Determine scheme from URL path prefix
 	var scheme string
 	var remotePath string
+	var remoteEscaped string
 	if strings.HasPrefix(r.URL.Path, "/https/") {
 		scheme = "https"
 		remotePath = strings.TrimPrefix(r.URL.Path, "/https/")
+		remoteEscaped = strings.TrimPrefix(r.URL.EscapedPath(), "/https/")
 	} else if strings.HasPrefix(r.URL.Path, "/http/") {
 		scheme = "http"
 		remotePath = strings.TrimPrefix(r.URL.Path, "/http/")
+		remoteEscaped = strings.TrimPrefix(r.URL.EscapedPath(), "/http/")
 	} else {
 		http.Error(w, "Invalid URL scheme", http.StatusBadRequest)
 		return
@@ -45,7 +48,7 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if this is a repo root URL (e.g., github.com/user/repo)
-	if candidates := ghub.ResolveRepoRootURLs(remotePath); candidates != nil {
+	if candidates := ghub.ResolveRepoRootURLs(remoteEscaped); candidates != nil {
 		for _, candidate := range candidates {
 			candidateURL := scheme + "://" + candidate
 			body, contentType, err := h.fetchRemote(candidateURL, remotePath)
@@ -59,8 +62,8 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve GitHub/GitLab blob URLs to raw URLs
-	fetchPath := remotePath
-	if resolved, ok := ghub.ResolveRawURL(remotePath); ok {
+	fetchPath := remoteEscaped
+	if resolved, ok := ghub.ResolveRawURL(remoteEscaped); ok {
 		fetchPath = resolved
 	}
 


### PR DESCRIPTION
## Summary

Closes #19

- Use `r.URL.EscapedPath()` instead of `r.URL.Path` for URL construction and resolution, preserving percent-encoding for non-ASCII characters
- Keep decoded `remotePath` for display (titles), extension detection, and credential lookup
- Add test cases for URL-encoded Japanese filenames (GitHub and GitLab)

## Test plan

- [x] `go test ./internal/github/` — new test cases pass
- [x] `go build ./cmd/markdown-proxy/` — build succeeds
- [x] Manual test with mock server: `curl http://127.0.0.1:19080/http/<mock>/docs/%E6%97%A5%E6%9C%AC%E8%AA%9E.md` and verify the mock server receives correctly encoded URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)