### PR TITLE
Fix HTML escaping in math renderers

### DIFF
--- a/internal/markdown/convert.go
+++ b/internal/markdown/convert.go
@@ -9,7 +9,9 @@ import (
 	highlighting "github.com/yuin/goldmark-highlighting/v2"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/util"
 )
 
 var md goldmark.Markdown
@@ -24,13 +26,22 @@ func init() {
 					chromahtml.WithClasses(true),
 				),
 			),
-			mathjax.MathJax,
 		),
 		goldmark.WithParserOptions(
 			parser.WithAutoHeadingID(),
+			parser.WithBlockParsers(
+				util.Prioritized(mathjax.NewMathJaxBlockParser(), 701),
+			),
+			parser.WithInlineParsers(
+				util.Prioritized(mathjax.NewInlineMathParser(), 501),
+			),
 		),
 		goldmark.WithRendererOptions(
 			html.WithUnsafe(),
+			renderer.WithNodeRenderers(
+				util.Prioritized(&SafeMathBlockRenderer{}, 501),
+				util.Prioritized(&SafeInlineMathRenderer{}, 502),
+			),
 		),
 	)
 }

--- a/internal/markdown/mathrender.go
+++ b/internal/markdown/mathrender.go
@@ -1,0 +1,62 @@
+package markdown
+
+import (
+	"bytes"
+	"html"
+
+	mathjax "github.com/litao91/goldmark-mathjax"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/util"
+)
+
+// SafeInlineMathRenderer renders InlineMath nodes with HTML escaping.
+// The upstream goldmark-mathjax renderer writes raw source bytes without
+// escaping, so characters like <, >, & break browser rendering.
+type SafeInlineMathRenderer struct{}
+
+func (r *SafeInlineMathRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(mathjax.KindInlineMath, r.renderInlineMath)
+}
+
+func (r *SafeInlineMathRenderer) renderInlineMath(w util.BufWriter, source []byte, n ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString(`<span class="math inline">\(`)
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			segment := c.(*ast.Text).Segment
+			value := segment.Value(source)
+			if bytes.HasSuffix(value, []byte("\n")) {
+				_, _ = w.WriteString(html.EscapeString(string(value[:len(value)-1])))
+				if c != n.LastChild() {
+					_, _ = w.Write([]byte(" "))
+				}
+			} else {
+				_, _ = w.WriteString(html.EscapeString(string(value)))
+			}
+		}
+		return ast.WalkSkipChildren, nil
+	}
+	_, _ = w.WriteString(`\)</span>`)
+	return ast.WalkContinue, nil
+}
+
+// SafeMathBlockRenderer renders MathBlock nodes with HTML escaping.
+type SafeMathBlockRenderer struct{}
+
+func (r *SafeMathBlockRenderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	reg.Register(mathjax.KindMathBlock, r.renderMathBlock)
+}
+
+func (r *SafeMathBlockRenderer) renderMathBlock(w util.BufWriter, source []byte, node ast.Node, entering bool) (ast.WalkStatus, error) {
+	if entering {
+		_, _ = w.WriteString(`<p><span class="math display">\[`)
+		l := node.Lines().Len()
+		for i := 0; i < l; i++ {
+			line := node.Lines().At(i)
+			_, _ = w.WriteString(html.EscapeString(string(line.Value(source))))
+		}
+	} else {
+		_, _ = w.WriteString(`\]</span></p>` + "\n")
+	}
+	return ast.WalkContinue, nil
+}

--- a/internal/markdown/mathrender_test.go
+++ b/internal/markdown/mathrender_test.go
@@ -1,0 +1,95 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestInlineMathHTMLEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "less than",
+			input:    "$a<b$",
+			contains: `<span class="math inline">\(a&lt;b\)</span>`,
+		},
+		{
+			name:     "greater than",
+			input:    "$a>b$",
+			contains: `<span class="math inline">\(a&gt;b\)</span>`,
+		},
+		{
+			name:     "ampersand",
+			input:    "$a&b$",
+			contains: `<span class="math inline">\(a&amp;b\)</span>`,
+		},
+		{
+			name:     "mixed special chars",
+			input:    "$a<b>c$",
+			contains: `<span class="math inline">\(a&lt;b&gt;c\)</span>`,
+		},
+		{
+			name:     "no special chars",
+			input:    "$x^2 + y^2 = z^2$",
+			contains: `<span class="math inline">\(x^2 + y^2 = z^2\)</span>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Convert([]byte(tt.input), "")
+			if err != nil {
+				t.Fatalf("Convert() error: %v", err)
+			}
+			got := string(result)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("Convert(%q)\ngot:    %s\nexpect to contain: %s", tt.input, got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestMathBlockHTMLEscape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "less than in block",
+			input:    "$$\na<b\n$$",
+			contains: `<span class="math display">\[a&lt;b`,
+		},
+		{
+			name:     "greater than in block",
+			input:    "$$\na>b\n$$",
+			contains: `<span class="math display">\[a&gt;b`,
+		},
+		{
+			name:     "ampersand in block",
+			input:    "$$\na&b\n$$",
+			contains: `<span class="math display">\[a&amp;b`,
+		},
+		{
+			name:     "no special chars in block",
+			input:    "$$\nx^2 + y^2\n$$",
+			contains: `<span class="math display">\[x^2 + y^2`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Convert([]byte(tt.input), "")
+			if err != nil {
+				t.Fatalf("Convert() error: %v", err)
+			}
+			got := string(result)
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("Convert(%q)\ngot:    %s\nexpect to contain: %s", tt.input, got, tt.contains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Replace goldmark-mathjax's default renderers with custom `SafeInlineMathRenderer` and `SafeMathBlockRenderer` that apply `html.EscapeString()` to math content
- Keep goldmark-mathjax's parsers as-is (they work correctly)
- Add tests for `<`, `>`, `&` in both inline and block math

Closes #21

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/markdown/...` passes (new tests for HTML special characters)
- [x] Browser verification: `$a<b$` renders correctly with KaTeX

🤖 Generated with [Claude Code](https://claude.com/claude-code)