### PR TITLE
Add HTML error page for authentication failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,72 @@ No configuration needed. Math expressions are automatically detected and rendere
 - **DNS rebinding prevention**: Resolved IP addresses are used directly for connections, preventing DNS rebinding attacks
 - **Constant-time token comparison**: Authentication uses `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
 
+## Private Repository Access
+
+markdown-proxy can access private repositories on GitHub and GitLab using your existing git credentials. When authentication is needed (e.g., 401, 403, or 404 from a private repo), markdown-proxy automatically invokes `git credential fill` to retrieve stored credentials.
+
+If credentials are not configured, an error page with setup guidance is displayed instead of a raw error message.
+
+### GitHub
+
+**Option A: GitHub CLI (recommended)**
+
+```bash
+gh auth login
+```
+
+This configures the git credential helper automatically.
+
+**Option B: Personal Access Token**
+
+1. Create a token at https://github.com/settings/tokens (classic) or https://github.com/settings/tokens?type=beta (fine-grained)
+2. Required scope: `repo` (classic) or repository read access (fine-grained)
+3. Store it via git credential helper:
+   ```bash
+   echo -e "protocol=https\nhost=github.com\n" | git credential fill
+   ```
+   If no credential is returned, configure a credential helper (e.g., `git config --global credential.helper store`) and save the token.
+
+### GitLab
+
+**gitlab.com:**
+
+```bash
+glab auth login
+```
+
+**Self-hosted GitLab:**
+
+`glab auth login --hostname` may not work on some self-hosted instances. If authentication fails, use a Personal Access Token (PAT) instead:
+
+1. Create a PAT at Settings > Access Tokens with `read_repository` scope
+2. Register it with glab:
+   ```bash
+   glab auth login --hostname gitlab.example.com --token <YOUR_TOKEN>
+   ```
+
+This stores the PAT in git's credential helper, which markdown-proxy uses automatically.
+
+### Organization-specific Credentials
+
+If you need different credentials for specific organizations, use path-based credential configuration:
+
+```gitconfig
+[credential "https://github.com/my-org"]
+    helper = !gh auth git-credential
+    useHttpPath = true
+```
+
+### Verifying Credentials
+
+To verify that git can provide credentials for a host:
+
+```bash
+echo -e "protocol=https\nhost=github.com\n" | git credential fill
+```
+
+This should output `username` and `password` fields. If nothing is returned, credentials are not configured for that host.
+
 ## Installation
 
 ### Download

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"errors"
+	"fmt"
 	"html/template"
 	"io"
 	"log"
@@ -49,6 +51,7 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Check if this is a repo root URL (e.g., github.com/user/repo)
 	if candidates := ghub.ResolveRepoRootURLs(remoteEscaped); candidates != nil {
+		var lastAuthErr *authError
 		for _, candidate := range candidates {
 			candidateURL := scheme + "://" + candidate
 			body, contentType, err := h.fetchRemote(candidateURL, remotePath)
@@ -56,6 +59,14 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				h.renderMarkdownResponse(w, body, contentType, remotePath, scheme)
 				return
 			}
+			var ae *authError
+			if errors.As(err, &ae) {
+				lastAuthErr = ae
+			}
+		}
+		if lastAuthErr != nil {
+			h.renderAuthError(w, lastAuthErr)
+			return
 		}
 		http.Error(w, "Could not find README.md in repository", http.StatusNotFound)
 		return
@@ -74,6 +85,11 @@ func (h *RemoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Pass remotePath for credential lookup (use original host, not resolved raw host)
 	body, contentType, err := h.fetchRemote(remoteURL, remotePath)
 	if err != nil {
+		var ae *authError
+		if errors.As(err, &ae) {
+			h.renderAuthError(w, ae)
+			return
+		}
 		http.Error(w, "Error fetching remote file: "+err.Error(), http.StatusBadGateway)
 		return
 	}
@@ -167,7 +183,12 @@ func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, strin
 		username, password, credErr := credential.GetToken(host, credPath)
 		if credErr != nil {
 			log.Printf("Warning: git credential failed for %s: %v", host, credErr)
-			return nil, "", err // return original HTTP error
+			return nil, "", &authError{
+				StatusCode: httpErr.StatusCode,
+				Host:       host,
+				Reason:     "credential_failed",
+				Err:        credErr,
+			}
 		}
 		if password != "" {
 			if username == "" {
@@ -175,9 +196,24 @@ func (h *RemoteHandler) fetchRemote(remoteURL, remotePath string) ([]byte, strin
 			}
 			log.Printf("Retrying with credential (user=%s) for %s", username, remoteURL)
 			// Authenticated retry follows redirects normally (for legitimate redirects)
-			return h.doFetch(remoteURL, username, password, true)
+			body, contentType, retryErr := h.doFetch(remoteURL, username, password, true)
+			if retryErr != nil {
+				return nil, "", &authError{
+					StatusCode: httpErr.StatusCode,
+					Host:       host,
+					Reason:     "auth_rejected",
+					Err:        retryErr,
+				}
+			}
+			return body, contentType, nil
 		}
 		log.Printf("Warning: git credential returned empty password for %s", host)
+		return nil, "", &authError{
+			StatusCode: httpErr.StatusCode,
+			Host:       host,
+			Reason:     "credential_empty",
+			Err:        err,
+		}
 	}
 
 	return nil, "", err
@@ -232,4 +268,94 @@ type httpError struct {
 
 func (e *httpError) Error() string {
 	return "remote server returned " + e.Status
+}
+
+// authError represents an authentication-related error when fetching remote files.
+type authError struct {
+	StatusCode int
+	Host       string
+	Reason     string // "credential_failed", "credential_empty", "auth_rejected"
+	Err        error
+}
+
+func (e *authError) Error() string {
+	return fmt.Sprintf("authentication failed for %s: %s", e.Host, e.Reason)
+}
+
+func (e *authError) Unwrap() error {
+	return e.Err
+}
+
+// buildAuthHints generates user-facing hint messages based on the auth failure reason and host.
+func buildAuthHints(host, reason string) []template.HTML {
+	safeHost := template.HTMLEscapeString(host)
+
+	var hints []template.HTML
+
+	// Reason-specific message
+	switch reason {
+	case "credential_failed":
+		hints = append(hints, "The git credential helper could not provide credentials. Make sure a credential helper is configured.")
+	case "credential_empty":
+		hints = append(hints, "The git credential helper returned an empty password. You may need to re-authenticate.")
+	case "auth_rejected":
+		hints = append(hints, "Credentials were provided but the server rejected them. The token may have expired or lack the required scope.")
+	}
+
+	// Host-specific setup hints
+	switch {
+	case host == "github.com" || strings.HasSuffix(host, ".github.com"):
+		hints = append(hints,
+			template.HTML("Run <code>gh auth login</code> to authenticate with GitHub CLI, or configure a Personal Access Token."),
+		)
+	case host == "gitlab.com" || strings.HasSuffix(host, ".gitlab.com"):
+		hints = append(hints,
+			template.HTML("Run <code>glab auth login</code> to authenticate with GitLab CLI, or configure a Personal Access Token with <code>read_repository</code> scope."),
+		)
+	default:
+		hints = append(hints,
+			template.HTML("Configure a git credential helper for <code>"+safeHost+"</code>. For self-hosted GitLab, create a Personal Access Token (<code>read_repository</code> scope) and run <code>glab auth login --hostname "+safeHost+" --token &lt;YOUR_TOKEN&gt;</code>."),
+		)
+	}
+
+	// Common documentation link
+	hints = append(hints,
+		template.HTML(`See <a href="https://git-scm.com/docs/gitcredentials" target="_blank" rel="noopener">git-credentials documentation</a> for more details.`),
+	)
+
+	return hints
+}
+
+// renderAuthError renders an HTML error page for authentication failures.
+func (h *RemoteHandler) renderAuthError(w http.ResponseWriter, ae *authError) {
+	statusCode := ae.StatusCode
+	// Map to user-friendly status: use 403 for auth errors regardless of the original status
+	// (GitHub returns 404 for private repos, but the user-facing message should indicate access denial)
+	if statusCode == 404 {
+		statusCode = 403
+	}
+
+	message := fmt.Sprintf(
+		"Could not access %s. This may be a private repository that requires authentication, or the resource may not exist.",
+		template.HTMLEscapeString(ae.Host),
+	)
+
+	hints := buildAuthHints(ae.Host, ae.Reason)
+
+	page, err := tmpl.RenderError(&tmpl.ErrorPageData{
+		Title:   "Access Denied",
+		Theme:   h.cfg.Theme,
+		Status:  statusCode,
+		Message: message,
+		Hints:   hints,
+	})
+	if err != nil {
+		log.Printf("Error rendering auth error page: %v", err)
+		http.Error(w, "Error fetching remote file: "+ae.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(statusCode)
+	w.Write(page)
 }

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -26,12 +26,24 @@ type DirPageData struct {
 	WatchPath string
 }
 
+type ErrorPageData struct {
+	Title   string
+	Theme   string
+	Status  int
+	Message string
+	Hints   []template.HTML
+}
+
 func RenderMarkdown(data *PageData) ([]byte, error) {
 	return renderTemplate(markdownPageTpl, data)
 }
 
 func RenderDirectory(data *DirPageData) ([]byte, error) {
 	return renderTemplate(dirPageTpl, data)
+}
+
+func RenderError(data *ErrorPageData) ([]byte, error) {
+	return renderTemplate(errorPageTpl, data)
 }
 
 func renderTemplate(tplStr string, data interface{}) ([]byte, error) {
@@ -200,5 +212,56 @@ function switchTheme(theme) {
 })();
 </script>
 {{end}}
+</body>
+</html>`
+
+const errorPageTpl = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{.Title}} - markdown-proxy</title>
+<style>` + githubCSS + `</style>
+<style>` + simpleCSS + `</style>
+<style>` + darkCSS + `</style>
+<style>` + commonCSS + `</style>
+</head>
+<body class="theme-{{.Theme}}">
+<div class="toolbar">
+  <a href="/" class="home-link">markdown-proxy</a>
+  <div class="theme-switcher">
+    <label>Theme:</label>
+    <select onchange="switchTheme(this.value)">
+      <option value="github"{{if eq .Theme "github"}} selected{{end}}>GitHub</option>
+      <option value="simple"{{if eq .Theme "simple"}} selected{{end}}>Simple</option>
+      <option value="dark"{{if eq .Theme "dark"}} selected{{end}}>Dark</option>
+    </select>
+  </div>
+</div>
+<div class="markdown-body">
+<h1>{{.Status}} — {{.Title}}</h1>
+<p>{{.Message}}</p>
+{{if .Hints}}
+<h3>What you can try</h3>
+<ul>
+{{range .Hints}}<li>{{.}}</li>
+{{end}}
+</ul>
+{{end}}
+</div>
+<script>
+function switchTheme(theme) {
+  document.body.className = 'theme-' + theme;
+  localStorage.setItem('mdproxy_theme', theme);
+}
+(function() {
+  var saved = localStorage.getItem('mdproxy_theme');
+  if (saved) {
+    document.body.className = 'theme-' + saved;
+    var sel = document.querySelector('.theme-switcher select');
+    if (sel) sel.value = saved;
+  }
+})();
+</script>
 </body>
 </html>`


### PR DESCRIPTION
## Summary

- Display a styled HTML error page with actionable hints when git credential authentication fails, replacing plain-text error messages
- Add `authError` type to distinguish failure reasons: credential helper failed, empty password returned, or server rejected credentials
- Show host-specific setup guidance (GitHub: `gh auth login`, GitLab: `glab auth login`, self-hosted: PAT with `read_repository` scope)
- Add "Private Repository Access" section to README.md with credential setup instructions

Closes #23

## Test plan

- [x] Access a private GitHub repo without credentials configured → verify HTML error page with GitHub-specific hints is displayed
- [x] Access a private GitLab repo without credentials → verify GitLab-specific hints
- [x] Access a public repo → verify normal rendering (no regression)
- [x] Access a non-existent repo → verify error page shows "may be private or may not exist" message
- [x] Verify theme switcher works on the error page
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)