### PR TITLE
Split $$ delimiters onto separate lines for multi-line math blocks

### DIFF
--- a/internal/markdown/mathblock.go
+++ b/internal/markdown/mathblock.go
@@ -12,14 +12,22 @@ var singleLineMathRe = regexp.MustCompile(`^(\s*)\$\$(.+)\$\$\s*$`)
 // fenceStartRe matches the start of a fenced code block (``` or ~~~).
 var fenceStartRe = regexp.MustCompile(`^(\x60{3,}|~{3,})`)
 
-// PreprocessMathBlocks converts single-line display math ($$...$$ on one line)
-// to multi-line format ($$\n...\n$$) so that goldmark-mathjax can parse it correctly.
+// PreprocessMathBlocks ensures that $$ delimiters are on their own lines
+// so that goldmark-mathjax can parse them correctly.
+// It handles three cases:
+//   - Single-line: $$content$$ → $$\ncontent\n$$
+//   - Opening with content: $$content...\n → $$\ncontent...\n
+//   - Closing with content: ...content$$ → ...content\n$$
+//
 // Fenced code blocks are skipped to avoid modifying code content.
+// Only exactly two consecutive $ characters are treated as delimiters
+// ($$$ or more are left for goldmark-mathjax to handle directly).
 func PreprocessMathBlocks(source []byte) []byte {
 	lines := bytes.Split(source, []byte("\n"))
 	var result [][]byte
 	var inFence bool
 	var fenceMarker []byte
+	var inMathBlock bool
 
 	for _, line := range lines {
 		if inFence {
@@ -43,6 +51,25 @@ func PreprocessMathBlocks(source []byte) []byte {
 			continue
 		}
 
+		if inMathBlock {
+			trimmed := bytes.TrimRight(line, " \t")
+			if countConsecutiveDollarsAt(trimmed, len(trimmed)-2) == 2 {
+				before := trimmed[:len(trimmed)-2]
+				if len(bytes.TrimSpace(before)) > 0 {
+					// Content before closing $$ → split
+					result = append(result, before)
+					result = append(result, []byte("$$"))
+				} else {
+					// Just $$ → proper closing delimiter
+					result = append(result, line)
+				}
+				inMathBlock = false
+			} else {
+				result = append(result, line)
+			}
+			continue
+		}
+
 		// Check for single-line $$...$$ pattern
 		if sm := singleLineMathRe.FindSubmatch(line); sm != nil {
 			indent := sm[1]
@@ -53,8 +80,46 @@ func PreprocessMathBlocks(source []byte) []byte {
 			continue
 		}
 
+		// Check for opening $$ (exactly 2 consecutive $)
+		trimmed := bytes.TrimLeft(line, " \t")
+		if countConsecutiveDollarsAt(trimmed, 0) == 2 {
+			indent := line[:len(line)-len(trimmed)]
+			content := trimmed[2:]
+			if len(bytes.TrimSpace(content)) > 0 {
+				// $$ followed by content → split
+				result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
+				result = append(result, append(append([]byte{}, indent...), content...))
+			} else {
+				// Just $$ → opening delimiter
+				result = append(result, line)
+			}
+			inMathBlock = true
+			continue
+		}
+
 		result = append(result, line)
 	}
 
 	return bytes.Join(result, []byte("\n"))
+}
+
+// countConsecutiveDollarsAt counts how many consecutive '$' characters
+// surround position pos. It returns the total length of the '$' run
+// that includes the character at pos.
+// If pos is out of range or the character at pos is not '$', it returns 0.
+func countConsecutiveDollarsAt(b []byte, pos int) int {
+	if pos < 0 || pos >= len(b) || b[pos] != '$' {
+		return 0
+	}
+	// Find the start of the $ run
+	start := pos
+	for start > 0 && b[start-1] == '$' {
+		start--
+	}
+	// Find the end of the $ run
+	end := pos + 1
+	for end < len(b) && b[end] == '$' {
+		end++
+	}
+	return end - start
 }

--- a/internal/markdown/mathblock_test.go
+++ b/internal/markdown/mathblock_test.go
@@ -10,6 +10,7 @@ func TestPreprocessMathBlocks(t *testing.T) {
 		input  string
 		expect string
 	}{
+		// Single-line $$...$$ (existing behavior)
 		{
 			name:   "single-line display math",
 			input:  "$$a=b$$",
@@ -31,10 +32,50 @@ func TestPreprocessMathBlocks(t *testing.T) {
 			expect: "$$\na=b\n$$",
 		},
 		{
+			name:   "complex LaTeX expression single-line",
+			input:  `$$\frac{a}{b} + \sqrt{c}$$`,
+			expect: "$$\n\\frac{a}{b} + \\sqrt{c}\n$$",
+		},
+
+		// Multi-line (proper format, unchanged)
+		{
 			name:   "multi-line display math unchanged",
 			input:  "$$\na=b\n$$",
 			expect: "$$\na=b\n$$",
 		},
+
+		// Opening $$ with content on same line
+		{
+			name:   "opening $$ with content",
+			input:  "$$\\begin{aligned}\na &= b\\\\\n&= c\n\\end{aligned}\n$$",
+			expect: "$$\n\\begin{aligned}\na &= b\\\\\n&= c\n\\end{aligned}\n$$",
+		},
+		{
+			name:   "opening $$ with content and indent",
+			input:  "  $$\\begin{aligned}\n  a=b\n  $$",
+			expect: "  $$\n  \\begin{aligned}\n  a=b\n  $$",
+		},
+
+		// Closing $$ with content on same line
+		{
+			name:   "closing $$ with content",
+			input:  "$$\n\\begin{aligned}\na &= b\\\\\n\\end{aligned}$$",
+			expect: "$$\n\\begin{aligned}\na &= b\\\\\n\\end{aligned}\n$$",
+		},
+		{
+			name:   "closing $$ with trailing whitespace",
+			input:  "$$\na=b$$  ",
+			expect: "$$\na=b\n$$",
+		},
+
+		// Both opening and closing with content
+		{
+			name:   "both opening and closing with content",
+			input:  "$$\\begin{aligned}\na &= b\\\\\n&= c\n\\end{aligned}$$",
+			expect: "$$\n\\begin{aligned}\na &= b\\\\\n&= c\n\\end{aligned}\n$$",
+		},
+
+		// Inline math (unchanged)
 		{
 			name:   "inline math unchanged",
 			input:  "text $a=b$ text",
@@ -45,6 +86,8 @@ func TestPreprocessMathBlocks(t *testing.T) {
 			input:  "text $$a=b$$ text",
 			expect: "text $$a=b$$ text",
 		},
+
+		// Fenced code blocks (unchanged)
 		{
 			name:   "inside fenced code block backticks",
 			input:  "```\n$$a=b$$\n```",
@@ -61,24 +104,38 @@ func TestPreprocessMathBlocks(t *testing.T) {
 			expect: "```math\n$$a=b$$\n```",
 		},
 		{
+			name:   "opening $$ with content inside fence",
+			input:  "```\n$$\\begin{aligned}\ncontent\n$$\n```",
+			expect: "```\n$$\\begin{aligned}\ncontent\n$$\n```",
+		},
+		{
 			name:   "after fenced code block",
 			input:  "```\ncode\n```\n$$a=b$$",
 			expect: "```\ncode\n```\n$$\na=b\n$$",
 		},
+
+		// Multiple math blocks
 		{
 			name:   "multiple math blocks",
 			input:  "$$x=1$$\ntext\n$$y=2$$",
 			expect: "$$\nx=1\n$$\ntext\n$$\ny=2\n$$",
 		},
+
+		// Edge cases
 		{
 			name:   "empty content between $$",
 			input:  "$$$$",
 			expect: "$$$$",
 		},
 		{
-			name:   "complex LaTeX expression",
-			input:  `$$\frac{a}{b} + \sqrt{c}$$`,
-			expect: "$$\n\\frac{a}{b} + \\sqrt{c}\n$$",
+			name:   "triple dollar not split",
+			input:  "$$$\ncontent\n$$$",
+			expect: "$$$\ncontent\n$$$",
+		},
+		{
+			name:   "triple dollar with content not split",
+			input:  "$$$content\nmore\ncontent$$$",
+			expect: "$$$content\nmore\ncontent$$$",
 		},
 		{
 			name:   "mixed content",


### PR DESCRIPTION
## Summary
- Extend `PreprocessMathBlocks` to handle multi-line `$$` math blocks where `$$` shares a line with content
- Track math block state (`inMathBlock`) to correctly split opening and closing delimiters
- Only target exactly 2 consecutive `$` characters; `$$$` or more are left untouched

Fixes #25

## Test plan
- [x] Existing single-line `$$content$$` tests pass
- [x] New test: opening `$$` with content on same line
- [x] New test: closing `$$` with content on same line
- [x] New test: both opening and closing with content
- [x] New test: `$$$` delimiters are not split
- [x] New test: fenced code blocks still skip processing
- [x] End-to-end: `$$\begin{aligned}...\end{aligned}$$` renders correctly via KaTeX

🤖 Generated with [Claude Code](https://claude.com/claude-code)