### PR TITLE
Avoid page breaks inside elements when printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ go build -o markdown-proxy ./cmd/markdown-proxy
 - **Markdown files only**: Only `.md` and `.markdown` files are converted to HTML. Other file types are served as-is.
 - **PlantUML disabled by default**: Diagram content is sent to an external server, so it requires explicit opt-in via `--plantuml-server`.
 - **GitHub/GitLab branch detection**: When accessing a repository root URL, only `main` and `master` branches are tried for README.md auto-detection.
-- **No native PDF export**: Use the toolbar's Print link to export via the browser's print-to-PDF feature.
+- **No native PDF export**: Use the toolbar's Print link to export via the browser's print-to-PDF feature. Page breaks are automatically avoided inside tables, code blocks, math expressions, images, blockquotes, and list items; headings are kept together with the following content.
 - **Hidden files excluded**: Files and directories starting with `.` are not shown in directory listings.
 
 ## Contributing

--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -21,7 +21,11 @@ body { margin: 0; padding: 0; }
 .toolbar-link:hover { text-decoration: underline; }
 .theme-switcher { display: flex; align-items: center; gap: 6px; font-size: 13px; }
 .theme-switcher select { padding: 2px 6px; font-size: 13px; }
-@media print { .toolbar { display: none; } }
+@media print {
+  .toolbar { display: none; }
+  table, pre, .math.display, img, blockquote, li { break-inside: avoid; }
+  h1, h2, h3, h4, h5, h6 { break-after: avoid; }
+}
 .markdown-body {
   max-width: 980px;
   margin: 0 auto;


### PR DESCRIPTION
Closes #29

## Summary
- Add `break-inside: avoid` for tables, code blocks, math expressions, images, blockquotes, and list items in `@media print`
- Add `break-after: avoid` for headings (h1–h6) to keep them with following content
- Update README to document the print page-break behavior

## Test plan
- [x] Open a Markdown file with tables, code blocks, and math expressions
- [x] Use the toolbar Print link and verify elements are not split across pages
- [x] Verify very large elements (e.g., long tables) still break when they must

🤖 Generated with [Claude Code](https://claude.com/claude-code)