### PR TITLE
Add line anchor links and file:/// URL rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ How markdown-proxy compares to other Markdown viewing tools:
 - Multiple CSS themes (GitHub, Simple, Dark) with switching UI
 - Live reload for local files (auto-refreshes browser on file changes)
 - Directory listing for local files
-- Link rewriting for seamless proxy navigation
+- Line anchor links: `[text](foo.md:12)` or `<a href="foo.md:12">` links navigate to specific source lines with highlighting
+- Link rewriting for seamless proxy navigation (including `file:///` protocol conversion)
 - Top page with smart input (auto-detects file path or URL)
 - Recently opened file history (localStorage)
 - Two operation modes: local mode and remote mode
@@ -105,6 +106,16 @@ Enter a local file path (e.g., `/path/to/README.md`) or a remote URL (e.g., `htt
 | Remote (HTTP) | `http://localhost:9080/http/server/path/to/file.md` |
 | Remote (HTTPS) | `http://localhost:9080/https/server/path/to/file.md` |
 | GitHub repo | `http://localhost:9080/https/github.com/user/repo/blob/main/README.md` |
+
+### Line Anchor Links
+
+Markdown files support line-level linking using the `file:line` syntax:
+
+- `[text](foo.md:12)` — links to line 12 of `foo.md`
+- `[text](foo.md:12-34)` — links to lines 12–34 of `foo.md`
+- `<a href="foo.md:12">text</a>` — same, using raw HTML
+
+When navigating to a line anchor (`#L12` or `#L12-L34`), the page scrolls to the target line and highlights the surrounding content. Highlighting is hidden in print output.
 
 ## Usage
 

--- a/internal/markdown/convert.go
+++ b/internal/markdown/convert.go
@@ -11,6 +11,7 @@ import (
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer"
 	"github.com/yuin/goldmark/renderer/html"
+	"github.com/yuin/goldmark/text"
 	"github.com/yuin/goldmark/util"
 )
 
@@ -55,8 +56,16 @@ func Convert(source []byte, plantumlServer string) ([]byte, error) {
 	// Pre-process: replace svg, mermaid, plantuml code blocks with raw HTML
 	source = PreprocessCodeBlocks(source, plantumlServer)
 
+	// Parse into AST
+	reader := text.NewReader(source)
+	doc := md.Parser().Parse(reader)
+
+	// Insert line anchors into AST
+	source = insertLineAnchors(doc, source)
+
+	// Render AST to HTML
 	var buf bytes.Buffer
-	if err := md.Convert(source, &buf); err != nil {
+	if err := md.Renderer().Render(&buf, source, doc); err != nil {
 		return nil, err
 	}
 

--- a/internal/markdown/lineanchor.go
+++ b/internal/markdown/lineanchor.go
@@ -1,0 +1,243 @@
+package markdown
+
+import (
+	"fmt"
+
+	"github.com/yuin/goldmark/ast"
+	east "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// insertLineAnchors walks the AST and inserts <a id="Ln"></a> anchors
+// for each source line that has corresponding content.
+// It appends anchor HTML to the source slice and returns the modified source.
+func insertLineAnchors(doc ast.Node, source []byte) []byte {
+	lineStarts := buildLineStarts(source)
+	seen := make(map[int]bool)
+
+	type insertion struct {
+		parent  ast.Node
+		before  ast.Node // insert before this child; nil means append
+		lineNum int
+		inline  bool // true: RawHTML (inline), false: HTMLBlock (block)
+	}
+	var insertions []insertion
+
+	ast.Walk(doc, func(node ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		kind := node.Kind()
+
+		// Paragraph and Heading: insert inline anchors for each text line
+		if kind == ast.KindParagraph || kind == ast.KindHeading {
+			for c := node.FirstChild(); c != nil; c = c.NextSibling() {
+				if c.Kind() == ast.KindText {
+					t := c.(*ast.Text)
+					line := byteOffsetToLine(t.Segment.Start, lineStarts)
+					if line > 0 && !seen[line] {
+						seen[line] = true
+						insertions = append(insertions, insertion{
+							parent: node, before: c,
+							lineNum: line, inline: true,
+						})
+					}
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		// TableCell: insert inline anchor for the cell's first text
+		if kind == east.KindTableCell {
+			line := firstChildTextLine(node, lineStarts)
+			if line > 0 && !seen[line] {
+				seen[line] = true
+				insertions = append(insertions, insertion{
+					parent: node, before: node.FirstChild(),
+					lineNum: line, inline: true,
+				})
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		// FencedCodeBlock: insert block anchor before it (for the fence line)
+		if kind == ast.KindFencedCodeBlock {
+			lines := node.Lines()
+			if lines.Len() > 0 {
+				// First content line; the fence is on the line before
+				contentLine := byteOffsetToLine(lines.At(0).Start, lineStarts)
+				fenceLine := contentLine - 1
+				if fenceLine < 1 {
+					fenceLine = 1
+				}
+				if !seen[fenceLine] {
+					seen[fenceLine] = true
+					insertions = append(insertions, insertion{
+						parent: node.Parent(), before: node,
+						lineNum: fenceLine, inline: false,
+					})
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		// CodeBlock (indented): insert block anchor before it
+		if kind == ast.KindCodeBlock {
+			lines := node.Lines()
+			if lines.Len() > 0 {
+				line := byteOffsetToLine(lines.At(0).Start, lineStarts)
+				if line > 0 && !seen[line] {
+					seen[line] = true
+					insertions = append(insertions, insertion{
+						parent: node.Parent(), before: node,
+						lineNum: line, inline: false,
+					})
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		// ThematicBreak (---): insert block anchor before it
+		if kind == ast.KindThematicBreak {
+			// ThematicBreak doesn't have Lines; estimate from surrounding nodes
+			prev := node.PreviousSibling()
+			if prev != nil {
+				prevLine := lastNodeLine(prev, lineStarts)
+				if prevLine > 0 {
+					line := prevLine + 1
+					// Skip blank lines
+					for line <= len(lineStarts) && isBlankLine(line, lineStarts, source) {
+						line++
+					}
+					if !seen[line] {
+						seen[line] = true
+						insertions = append(insertions, insertion{
+							parent: node.Parent(), before: node,
+							lineNum: line, inline: false,
+						})
+					}
+				}
+			}
+			return ast.WalkSkipChildren, nil
+		}
+
+		// List, ListItem, Blockquote, Table, TableHeader, TableBody, TableRow:
+		// These are container nodes; continue walking to process their children.
+		return ast.WalkContinue, nil
+	})
+
+	// Apply insertions
+	for _, ins := range insertions {
+		anchorHTML := fmt.Sprintf(`<a id="L%d"></a>`, ins.lineNum)
+		start := len(source)
+		source = append(source, []byte(anchorHTML)...)
+		end := len(source)
+
+		if ins.inline {
+			raw := ast.NewRawHTML()
+			raw.Segments.Append(text.NewSegment(start, end))
+			if ins.before != nil {
+				ins.parent.InsertBefore(ins.parent, ins.before, raw)
+			} else {
+				ins.parent.AppendChild(ins.parent, raw)
+			}
+		} else {
+			block := ast.NewHTMLBlock(ast.HTMLBlockType7)
+			block.Lines().Append(text.NewSegment(start, end))
+			if ins.before != nil {
+				ins.parent.InsertBefore(ins.parent, ins.before, block)
+			} else {
+				ins.parent.AppendChild(ins.parent, block)
+			}
+		}
+	}
+
+	return source
+}
+
+// buildLineStarts returns byte offsets where each line begins.
+// lineStarts[0] = offset of line 1, lineStarts[1] = offset of line 2, etc.
+func buildLineStarts(source []byte) []int {
+	starts := []int{0} // line 1 starts at offset 0
+	for i, b := range source {
+		if b == '\n' && i+1 <= len(source) {
+			starts = append(starts, i+1)
+		}
+	}
+	return starts
+}
+
+// byteOffsetToLine converts a byte offset to a 1-based line number.
+func byteOffsetToLine(offset int, lineStarts []int) int {
+	// Binary search for the line containing the offset
+	lo, hi := 0, len(lineStarts)-1
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		if lineStarts[mid] <= offset {
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return lo // 1-based line number (since lineStarts[0] = line 1)
+}
+
+// firstChildTextLine returns the line number of the first Text child node.
+func firstChildTextLine(node ast.Node, lineStarts []int) int {
+	for c := node.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Kind() == ast.KindText {
+			t := c.(*ast.Text)
+			return byteOffsetToLine(t.Segment.Start, lineStarts)
+		}
+	}
+	return 0
+}
+
+// lastNodeLine returns the last source line number of a node's content.
+func lastNodeLine(node ast.Node, lineStarts []int) int {
+	lines := node.Lines()
+	if lines != nil && lines.Len() > 0 {
+		lastSeg := lines.At(lines.Len() - 1)
+		return byteOffsetToLine(lastSeg.Stop-1, lineStarts)
+	}
+	// Check children recursively
+	var lastLine int
+	for c := node.FirstChild(); c != nil; c = c.NextSibling() {
+		l := lastNodeLine(c, lineStarts)
+		if l > lastLine {
+			lastLine = l
+		}
+	}
+	// Check inline Text children
+	for c := node.FirstChild(); c != nil; c = c.NextSibling() {
+		if c.Kind() == ast.KindText {
+			t := c.(*ast.Text)
+			l := byteOffsetToLine(t.Segment.Stop-1, lineStarts)
+			if l > lastLine {
+				lastLine = l
+			}
+		}
+	}
+	return lastLine
+}
+
+// isBlankLine returns true if the given line number is a blank line.
+func isBlankLine(line int, lineStarts []int, source []byte) bool {
+	if line < 1 || line > len(lineStarts) {
+		return false
+	}
+	start := lineStarts[line-1]
+	var end int
+	if line < len(lineStarts) {
+		end = lineStarts[line]
+	} else {
+		end = len(source)
+	}
+	for i := start; i < end; i++ {
+		if source[i] != ' ' && source[i] != '\t' && source[i] != '\n' && source[i] != '\r' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/markdown/rewrite.go
+++ b/internal/markdown/rewrite.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+// lineRefRe matches :line or :line-line at the end of a markdown file URL.
+// e.g., "foo.md:12" or "foo.md:12-34"
+var lineRefRe = regexp.MustCompile(`^(.*\.(?:md|markdown)):(\d+)(?:-(\d+))?$`)
+
 var (
 	hrefRe = regexp.MustCompile(`(<a\s[^>]*href=")([^"]+)(")`)
 	srcRe  = regexp.MustCompile(`(<img\s[^>]*src=")([^"]+)(")`)
@@ -44,6 +48,15 @@ func RewriteLinks(htmlContent []byte, scheme string, server string) []byte {
 }
 
 func rewriteURL(url, scheme, server string) string {
+	// Convert line references: file.md:12 → file.md#L12, file.md:12-34 → file.md#L12-L34
+	url = convertLineRef(url)
+
+	// file:/// URL → proxy via /local/
+	if strings.HasPrefix(url, "file:///") {
+		// file:///path/to/file.md → /local/path/to/file.md
+		return "/local" + strings.TrimPrefix(url, "file://")
+	}
+
 	// External URL with .md extension → proxy via /http/ or /https/
 	if strings.HasPrefix(url, "https://") {
 		if isMarkdownOrDir(url) {
@@ -74,6 +87,29 @@ func rewriteURL(url, scheme, server string) string {
 	}
 
 	return url
+}
+
+// convertLineRef converts file.md:12 to file.md#L12 and file.md:12-34 to file.md#L12-L34.
+func convertLineRef(url string) string {
+	// Strip existing fragment/query for matching
+	base := url
+	if idx := strings.IndexAny(base, "?#"); idx >= 0 {
+		base = base[:idx]
+	}
+
+	m := lineRefRe.FindStringSubmatch(base)
+	if m == nil {
+		return url
+	}
+
+	filePath := m[1]
+	startLine := m[2]
+	endLine := m[3]
+
+	if endLine != "" {
+		return filePath + "#L" + startLine + "-L" + endLine
+	}
+	return filePath + "#L" + startLine
 }
 
 func isMarkdownOrDir(url string) bool {

--- a/internal/template/lineanchor.go
+++ b/internal/template/lineanchor.go
@@ -1,0 +1,80 @@
+package template
+
+const lineAnchorJS = `<script>
+(function() {
+  function highlightLines() {
+    // Clear previous highlights
+    document.querySelectorAll('.line-highlight').forEach(function(el) {
+      el.classList.remove('line-highlight');
+    });
+
+    var hash = location.hash;
+    if (!hash) return;
+
+    // Parse #L12 or #L12-L34
+    var m = hash.match(/^#L(\d+)(?:-L(\d+))?$/);
+    if (!m) return;
+
+    var startLine = parseInt(m[1], 10);
+    var endLine = m[2] ? parseInt(m[2], 10) : startLine;
+
+    // Find all line anchor elements in range
+    var anchors = [];
+    for (var i = startLine; i <= endLine; i++) {
+      var el = document.getElementById('L' + i);
+      if (el) anchors.push(el);
+    }
+    if (anchors.length === 0) {
+      // Try to find the nearest anchor before startLine
+      for (var i = startLine - 1; i >= 1; i--) {
+        var el = document.getElementById('L' + i);
+        if (el) {
+          el.scrollIntoView({behavior: 'smooth', block: 'center'});
+          return;
+        }
+      }
+      return;
+    }
+
+    // Scroll to first anchor
+    anchors[0].scrollIntoView({behavior: 'smooth', block: 'center'});
+
+    // Highlight: find the parent block element of each anchor and highlight it
+    var highlighted = new Set();
+    anchors.forEach(function(anchor) {
+      // Walk up to find the nearest block-level parent that contains content
+      var parent = anchor.parentElement;
+      while (parent && parent.classList.contains('markdown-body')) {
+        parent = null;
+        break;
+      }
+      if (parent && !highlighted.has(parent)) {
+        highlighted.add(parent);
+        parent.classList.add('line-highlight');
+      }
+    });
+  }
+
+  // Run on page load and hash change
+  window.addEventListener('hashchange', highlightLines);
+  window.addEventListener('DOMContentLoaded', highlightLines);
+})();
+</script>`
+
+const lineAnchorCSS = `
+.line-highlight {
+  background-color: rgba(255, 255, 0, 0.2) !important;
+  border-left: 3px solid #f0c040 !important;
+  transition: background-color 0.3s ease;
+}
+.theme-dark .line-highlight {
+  background-color: rgba(255, 255, 0, 0.1) !important;
+  border-left: 3px solid #b08820 !important;
+}
+@media print {
+  .line-highlight {
+    background-color: transparent !important;
+    border-left: none !important;
+  }
+}
+`

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -86,6 +86,7 @@ const markdownPageTplHead = `<!DOCTYPE html>
 <style>` + simpleCSS + `</style>
 <style>` + darkCSS + `</style>
 <style>` + commonCSS + `</style>
+<style>` + lineAnchorCSS + `</style>
 `
 
 const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
@@ -147,6 +148,7 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 </script>
+` + lineAnchorJS + `
 {{if .WatchPath}}
 <script>
 (function() {


### PR DESCRIPTION
## Summary

Closes #31

- Support `file:line` reference syntax in links (`foo.md:12` → `foo.md#L12`, `foo.md:12-34` → `foo.md#L12-L34`)
- Insert per-source-line anchors (`<a id="Ln"></a>`) into rendered HTML via goldmark AST transformation
- Add client-side scroll and highlight for `#L12` / `#L12-L34` fragments (theme-aware, hidden in print)
- Rewrite `file:///` protocol URLs to `/local/` proxy paths

## Test plan

- [x] Verify `[text](foo.md:12)` renders as `<a href="foo.md#L12">text</a>` and navigates correctly
- [x] Verify `<a href="foo.md:12">text</a>` raw HTML links are also converted
- [x] Verify range syntax `foo.md:12-34` produces `#L12-L34` fragment
- [x] Verify `#L12` scrolls to the correct position and highlights the content
- [x] Verify `#L12-L34` highlights the range
- [x] Verify highlighting is hidden in print output
- [x] Verify `file:///path/to/file.md` links are rewritten to `/local/path/to/file.md`
- [x] Verify existing links (relative, absolute, external) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)