### PR TITLE
Add line anchor support for .txt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ How markdown-proxy compares to other Markdown viewing tools:
 - Multiple CSS themes (GitHub, Simple, Dark) with switching UI
 - Live reload for local files (auto-refreshes browser on file changes)
 - Directory listing for local files
-- Line anchor links: `[text](foo.md:12)` or `<a href="foo.md:12">` links navigate to specific source lines with highlighting
+- Line anchor links: `[text](foo.md:12)` or `<a href="foo.md:12">` links navigate to specific source lines with highlighting (Markdown and text files)
+- Text file rendering: `.txt` files are displayed in HTML with line anchors, themes, and live reload
 - Link rewriting for seamless proxy navigation (including `file:///` protocol conversion)
 - Top page with smart input (auto-detects file path or URL)
 - Recently opened file history (localStorage)
@@ -109,13 +110,14 @@ Enter a local file path (e.g., `/path/to/README.md`) or a remote URL (e.g., `htt
 
 ### Line Anchor Links
 
-Markdown files support line-level linking using the `file:line` syntax:
+Markdown and text files support line-level linking using the `file:line` syntax:
 
 - `[text](foo.md:12)` — links to line 12 of `foo.md`
 - `[text](foo.md:12-34)` — links to lines 12–34 of `foo.md`
+- `[text](foo.txt:12)` — links to line 12 of `foo.txt`
 - `<a href="foo.md:12">text</a>` — same, using raw HTML
 
-When navigating to a line anchor (`#L12` or `#L12-L34`), the page scrolls to the target line and highlights the surrounding content. Highlighting is hidden in print output.
+When navigating to a line anchor (`#L12` or `#L12-L34`), the page scrolls to the target line and highlights the surrounding content. For text files, individual lines are highlighted; for Markdown files, the containing block element is highlighted. Highlighting is hidden in print output.
 
 ## Usage
 
@@ -313,7 +315,7 @@ go build -o markdown-proxy ./cmd/markdown-proxy
 ## Known Limitations
 
 - **Read-only viewer**: No editing capabilities; this is a rendering-only tool.
-- **Markdown files only**: Only `.md` and `.markdown` files are converted to HTML. Other file types are served as-is.
+- **Limited file type support**: Only `.md`, `.markdown`, and `.txt` files are rendered as HTML. Other file types are served as-is.
 - **PlantUML disabled by default**: Diagram content is sent to an external server, so it requires explicit opt-in via `--plantuml-server`.
 - **GitHub/GitLab branch detection**: When accessing a repository root URL, only `main` and `master` branches are tried for README.md auto-detection.
 - **No native PDF export**: Use the toolbar's Print link to export via the browser's print-to-PDF feature. Page breaks are automatically avoided inside tables, code blocks, math expressions, images, blockquotes, and list items; headings are kept together with the following content.

--- a/internal/handler/local.go
+++ b/internal/handler/local.go
@@ -75,6 +75,24 @@ func (h *LocalHandler) serveFile(w http.ResponseWriter, filePath string) {
 
 	ext := strings.ToLower(filepath.Ext(filePath))
 
+	// Text files: convert to HTML with line anchors
+	if ext == ".txt" {
+		htmlContent := markdown.ConvertText(data)
+		page, err := tmpl.RenderMarkdown(&tmpl.PageData{
+			Title:     filepath.Base(filePath),
+			Content:   template.HTML(htmlContent),
+			Theme:     h.cfg.Theme,
+			WatchPath: filePath,
+		})
+		if err != nil {
+			http.Error(w, "Error rendering page: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(page)
+		return
+	}
+
 	// Non-markdown files: serve as-is
 	if ext != ".md" && ext != ".markdown" {
 		contentType := mime.TypeByExtension(ext)

--- a/internal/handler/remote.go
+++ b/internal/handler/remote.go
@@ -129,6 +129,26 @@ func (h *RemoteHandler) renderResponse(w http.ResponseWriter, body []byte, conte
 	// fetchPath may be a GitLab API URL (ending in /raw?ref=...) which has no file extension.
 	ext := strings.ToLower(path.Ext(remotePath))
 
+	// Text files: convert to HTML with line anchors
+	if ext == ".txt" {
+		htmlContent := markdown.ConvertText(body)
+		server := ghub.HostFromPath(remotePath)
+		htmlContent = markdown.RewriteLinks(htmlContent, scheme, server)
+		page, err := tmpl.RenderMarkdown(&tmpl.PageData{
+			Title:     path.Base(remotePath),
+			Content:   template.HTML(htmlContent),
+			Theme:     h.cfg.Theme,
+			SourceURL: scheme + "://" + remotePath,
+		})
+		if err != nil {
+			http.Error(w, "Error rendering page: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write(page)
+		return
+	}
+
 	// Non-markdown files: pass through
 	if ext != ".md" && ext != ".markdown" {
 		if contentType != "" {

--- a/internal/markdown/rewrite.go
+++ b/internal/markdown/rewrite.go
@@ -7,7 +7,7 @@ import (
 
 // lineRefRe matches :line or :line-line at the end of a markdown file URL.
 // e.g., "foo.md:12" or "foo.md:12-34"
-var lineRefRe = regexp.MustCompile(`^(.*\.(?:md|markdown)):(\d+)(?:-(\d+))?$`)
+var lineRefRe = regexp.MustCompile(`^(.*\.(?:md|markdown|txt)):(\d+)(?:-(\d+))?$`)
 
 var (
 	hrefRe = regexp.MustCompile(`(<a\s[^>]*href=")([^"]+)(")`)

--- a/internal/markdown/textconv.go
+++ b/internal/markdown/textconv.go
@@ -1,0 +1,30 @@
+package markdown
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"strings"
+)
+
+// ConvertText converts plain text content to HTML with line anchors.
+// Each line is wrapped in a <span id="Ln" class="source-line"> for
+// individual line-level highlighting. The output is in a <pre><code> block.
+func ConvertText(source []byte) []byte {
+	lines := strings.Split(string(source), "\n")
+
+	var buf bytes.Buffer
+	buf.WriteString("<pre><code>")
+	for i, line := range lines {
+		lineNum := i + 1
+		fmt.Fprintf(&buf, `<span id="L%d" class="source-line">`, lineNum)
+		buf.WriteString(html.EscapeString(line))
+		buf.WriteString("</span>")
+		if lineNum < len(lines) {
+			buf.WriteByte('\n')
+		}
+	}
+	buf.WriteString("</code></pre>\n")
+
+	return buf.Bytes()
+}

--- a/internal/template/lineanchor.go
+++ b/internal/template/lineanchor.go
@@ -39,18 +39,23 @@ const lineAnchorJS = `<script>
     // Scroll to first anchor
     anchors[0].scrollIntoView({behavior: 'smooth', block: 'center'});
 
-    // Highlight: find the parent block element of each anchor and highlight it
+    // Highlight: for source-line spans (text files), highlight the element directly;
+    // for markdown anchors, highlight the parent block element.
     var highlighted = new Set();
     anchors.forEach(function(anchor) {
-      // Walk up to find the nearest block-level parent that contains content
-      var parent = anchor.parentElement;
-      while (parent && parent.classList.contains('markdown-body')) {
-        parent = null;
-        break;
+      var target;
+      if (anchor.classList.contains('source-line')) {
+        target = anchor;
+      } else {
+        target = anchor.parentElement;
+        while (target && target.classList.contains('markdown-body')) {
+          target = null;
+          break;
+        }
       }
-      if (parent && !highlighted.has(parent)) {
-        highlighted.add(parent);
-        parent.classList.add('line-highlight');
+      if (target && !highlighted.has(target)) {
+        highlighted.add(target);
+        target.classList.add('line-highlight');
       }
     });
   }


### PR DESCRIPTION
## Summary

- Render `.txt` files as HTML with the same template as Markdown (themes, live reload, line anchor JS/CSS)
- Wrap each line in `<span id="Ln" class="source-line">` for per-line highlighting
- Extend `lineRefRe` to support `foo.txt:12` → `foo.txt#L12` syntax
- Update highlight JS to directly highlight `source-line` elements instead of parent block

Closes #33

## Test plan

- [x] Open a `.txt` file via `/local/path/to/file.txt` and verify it renders in HTML with themes
- [x] Navigate to `file.txt#L5` and verify line 5 is highlighted (not the entire block)
- [x] Navigate to `file.txt#L3-L7` and verify lines 3–7 are highlighted
- [x] Verify `[text](foo.txt:12)` links in Markdown are converted to `foo.txt#L12`
- [x] Verify live reload works for `.txt` files
- [x] Verify Markdown line anchors still work correctly (no regression)
- [x] Verify remote `.txt` files render correctly via `/https/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)