### PR TITLE
Wrap long lines in text file display

### DIFF
--- a/internal/markdown/textconv.go
+++ b/internal/markdown/textconv.go
@@ -14,7 +14,7 @@ func ConvertText(source []byte) []byte {
 	lines := strings.Split(string(source), "\n")
 
 	var buf bytes.Buffer
-	buf.WriteString("<pre><code>")
+	buf.WriteString("<pre class=\"text-file\"><code>")
 	for i, line := range lines {
 		lineNum := i + 1
 		fmt.Fprintf(&buf, `<span id="L%d" class="source-line">`, lineNum)

--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -26,6 +26,9 @@ body { margin: 0; padding: 0; }
   table, pre, .math.display, img, blockquote, li { break-inside: avoid; }
   h1, h2, h3, h4, h5, h6 { break-after: avoid; }
 }
+.markdown-body pre.text-file {
+  white-space: pre-wrap;
+}
 .markdown-body {
   max-width: 980px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- Add `text-file` class to `<pre>` tag in text file rendering (`textconv.go`)
- Apply `white-space: pre-wrap` CSS for `.markdown-body pre.text-file` only
- Markdown code blocks are not affected

Closes #35

## Test plan
- [x] Open a text file with long lines and verify they wrap
- [x] Open a markdown file with code blocks and verify they still scroll horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)