### PR TITLE
Fix nested <a> tags breaking links in markdown

### DIFF
--- a/internal/markdown/lineanchor.go
+++ b/internal/markdown/lineanchor.go
@@ -129,7 +129,7 @@ func insertLineAnchors(doc ast.Node, source []byte) []byte {
 
 	// Apply insertions
 	for _, ins := range insertions {
-		anchorHTML := fmt.Sprintf(`<a id="L%d"></a>`, ins.lineNum)
+		anchorHTML := fmt.Sprintf(`<span id="L%d"></span>`, ins.lineNum)
 		start := len(source)
 		source = append(source, []byte(anchorHTML)...)
 		end := len(source)


### PR DESCRIPTION
## Summary
- Line anchors used `<a id="Ln"></a>` which created invalid nested `<a>` tags when inserted inside raw HTML links (e.g. `<a href="../魔法少女まどか☆マギカ.txt#L10">`), causing browsers to break the link
- Changed to `<span id="Ln"></span>` which can safely nest inside anchor elements
- `getElementById()` and scroll/highlight behavior are unaffected by this change

## Test plan
- [x] Verify markdown files with raw HTML `<a href="...">` links render as clickable links
- [x] Verify `#L10` line anchor scrolling and highlighting still works
- [x] Verify links to files with Japanese/special characters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)