### PR TITLE
Add config file support, --configure option, and PlantUML notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ How markdown-proxy compares to other Markdown viewing tools:
   - Mermaid: client-side rendering via mermaid.js from ```` ```mermaid ```` code blocks
   - PlantUML: server-side rendering from ```` ```plantuml ```` code blocks (requires `--plantuml-server`)
     - Disabled by default because diagram content is sent to the specified server
+    - When disabled, a hint is shown in place of each PlantUML block
     - To use the public server: `--plantuml-server https://www.plantuml.com/plantuml`
+    - Use `--configure` to save the setting permanently
 - GitHub/GitLab integration
   - Blob URL auto-conversion to raw URL (supports self-hosted GitLab with custom domains)
   - Authentication via git credential helper (supports path-based credential matching)
@@ -72,6 +74,7 @@ How markdown-proxy compares to other Markdown viewing tools:
 - Two operation modes: local mode and remote mode
 - Token-based authentication for remote access
 - Access logging with automatic log rotation
+- Configuration file (`~/.config/markdown-proxy/config.json`) with interactive setup via `--configure`
 - Single binary, no runtime dependencies
 
 ## Quick Start
@@ -142,7 +145,42 @@ markdown-proxy [options]
 | `-access-log-max-backups` | Max number of old log files to retain | `3` |
 | `-access-log-max-age` | Max days to retain old log files | `28` |
 | `-verbose`, `-v` | Enable debug logging to stderr | `false` |
+| `-configure` | Interactively create configuration file | |
 | `-version` | Show version and exit | |
+
+## Configuration File
+
+Settings can be saved to a configuration file so you don't need to pass flags every time.
+
+### Interactive Setup
+
+```bash
+markdown-proxy --configure
+```
+
+This walks you through each setting interactively and saves the result.
+
+### File Location
+
+| Platform | Path |
+|----------|------|
+| Linux | `~/.config/markdown-proxy/config.json` |
+| Windows | `%APPDATA%/markdown-proxy/config.json` |
+
+### Supported Settings
+
+The configuration file stores these settings as JSON:
+
+```json
+{
+  "plantuml-server": "https://www.plantuml.com/plantuml",
+  "theme": "dark",
+  "port": 9080,
+  "listen": "127.0.0.1"
+}
+```
+
+Command-line flags override configuration file values. Security-sensitive settings (`-auth-token`, `-access-log`, etc.) are not stored in the config file.
 
 ## Operation Modes
 
@@ -316,7 +354,7 @@ go build -o markdown-proxy ./cmd/markdown-proxy
 
 - **Read-only viewer**: No editing capabilities; this is a rendering-only tool.
 - **Limited file type support**: Only `.md`, `.markdown`, and `.txt` files are rendered as HTML. Other file types are served as-is.
-- **PlantUML disabled by default**: Diagram content is sent to an external server, so it requires explicit opt-in via `--plantuml-server`.
+- **PlantUML disabled by default**: Diagram content is sent to an external server, so it requires explicit opt-in via `--plantuml-server` or `--configure`. When disabled, a hint message is shown in place of PlantUML blocks.
 - **GitHub/GitLab branch detection**: When accessing a repository root URL, only `main` and `master` branches are tried for README.md auto-detection.
 - **No native PDF export**: Use the toolbar's Print link to export via the browser's print-to-PDF feature. Page breaks are automatically avoided inside tables, code blocks, math expressions, images, blockquotes, and list items; headings are kept together with the following content.
 - **Hidden files excluded**: Files and directories starting with `.` are not shown in directory listings.

--- a/cmd/markdown-proxy/main.go
+++ b/cmd/markdown-proxy/main.go
@@ -19,6 +19,12 @@ func main() {
 		fmt.Println(version)
 		os.Exit(0)
 	}
+	if cfg.Configure {
+		if err := config.RunConfigure(os.Stdin, os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 	if err := cfg.Validate(); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 )
 
 type Config struct {
@@ -17,23 +20,83 @@ type Config struct {
 	AccessLogMaxSize int
 	AccessLogMaxBack int
 	AccessLogMaxAge  int
+	Configure        bool
+}
+
+// configFilePathFunc returns the path to the configuration file.
+// It is a variable so tests can override it.
+var configFilePathFunc = defaultConfigFilePath
+
+func defaultConfigFilePath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "markdown-proxy", "config.json"), nil
+}
+
+// fileConfig holds the settings that can be persisted in the config file.
+type fileConfig struct {
+	PlantUMLServer string `json:"plantuml-server,omitempty"`
+	Theme          string `json:"theme,omitempty"`
+	Port           int    `json:"port,omitempty"`
+	Listen         string `json:"listen,omitempty"`
+	Verbose        bool   `json:"verbose,omitempty"`
+}
+
+// loadConfigFile reads the config file and returns the parsed values.
+// Returns a zero-value fileConfig if the file does not exist.
+func loadConfigFile() fileConfig {
+	var fc fileConfig
+	path, err := configFilePathFunc()
+	if err != nil {
+		return fc
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fc
+	}
+	_ = json.Unmarshal(data, &fc)
+	return fc
 }
 
 func Parse() *Config {
 	c := &Config{}
-	flag.IntVar(&c.Port, "port", 9080, "Listen port")
-	flag.IntVar(&c.Port, "p", 9080, "Listen port (shorthand)")
-	flag.StringVar(&c.Listen, "listen", "127.0.0.1", "Bind address (use 0.0.0.0 for remote access)")
-	flag.StringVar(&c.Theme, "theme", "github", "Default CSS theme")
-	flag.StringVar(&c.PlantUMLServer, "plantuml-server", "", "PlantUML server URL (disabled by default; e.g. https://www.plantuml.com/plantuml)")
-	flag.BoolVar(&c.Verbose, "verbose", false, "Enable debug logging")
-	flag.BoolVar(&c.Verbose, "v", false, "Enable debug logging (shorthand)")
+
+	// Load config file values as defaults
+	fc := loadConfigFile()
+	defaultPort := 9080
+	if fc.Port != 0 {
+		defaultPort = fc.Port
+	}
+	defaultListen := "127.0.0.1"
+	if fc.Listen != "" {
+		defaultListen = fc.Listen
+	}
+	defaultTheme := "github"
+	if fc.Theme != "" {
+		defaultTheme = fc.Theme
+	}
+	defaultPlantUML := ""
+	if fc.PlantUMLServer != "" {
+		defaultPlantUML = fc.PlantUMLServer
+	}
+	defaultVerbose := fc.Verbose
+
+	flag.IntVar(&c.Port, "port", defaultPort, "Listen port")
+	flag.IntVar(&c.Port, "p", defaultPort, "Listen port (shorthand)")
+	flag.StringVar(&c.Listen, "listen", defaultListen, "Bind address (use 0.0.0.0 for remote access)")
+	flag.StringVar(&c.Theme, "theme", defaultTheme, "Default CSS theme")
+	flag.StringVar(&c.PlantUMLServer, "plantuml-server", defaultPlantUML, "PlantUML server URL (disabled by default; e.g. https://www.plantuml.com/plantuml)")
+	flag.BoolVar(&c.Verbose, "verbose", defaultVerbose, "Enable debug logging")
+	flag.BoolVar(&c.Verbose, "v", defaultVerbose, "Enable debug logging (shorthand)")
 	flag.StringVar(&c.AuthToken, "auth-token", "", "Authentication token (required in remote mode)")
 	flag.IntVar(&c.AuthCookieMaxAge, "auth-cookie-max-age", 30, "Authentication cookie max age in days")
 	flag.StringVar(&c.AccessLog, "access-log", "", "Access log file path")
 	flag.IntVar(&c.AccessLogMaxSize, "access-log-max-size", 100, "Access log max size in MB before rotation")
 	flag.IntVar(&c.AccessLogMaxBack, "access-log-max-backups", 3, "Max number of old access log files to retain")
 	flag.IntVar(&c.AccessLogMaxAge, "access-log-max-age", 28, "Max number of days to retain old access log files")
+	flag.BoolVar(&c.Configure, "configure", false, "Interactively create configuration file")
 	flag.Parse()
 	return c
 }

--- a/internal/config/configure.go
+++ b/internal/config/configure.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// RunConfigure runs the interactive configuration wizard.
+// It reads from r and writes prompts to w, then saves the result to the config file.
+func RunConfigure(r io.Reader, w io.Writer) error {
+	// Load existing config as defaults
+	fc := loadConfigFile()
+
+	scanner := bufio.NewScanner(r)
+
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "markdown-proxy configuration")
+	fmt.Fprintln(w, "=============================")
+	fmt.Fprintln(w, "")
+
+	// PlantUML server
+	fmt.Fprintln(w, "PlantUML server URL (empty to disable):")
+	fmt.Fprintln(w, "  WARNING: Diagram content will be sent to the specified server.")
+	fmt.Fprintln(w, "  Use a self-hosted server for sensitive diagrams.")
+	fmt.Fprintln(w, "  Public server: https://www.plantuml.com/plantuml")
+	fc.PlantUMLServer = promptString(scanner, w, fc.PlantUMLServer)
+	fmt.Fprintln(w, "")
+
+	// Theme
+	defaultTheme := fc.Theme
+	if defaultTheme == "" {
+		defaultTheme = "github"
+	}
+	fmt.Fprintf(w, "Default theme (github/simple/dark) [%s]:\n", defaultTheme)
+	val := promptString(scanner, w, defaultTheme)
+	if val == "" {
+		val = defaultTheme
+	}
+	fc.Theme = val
+	fmt.Fprintln(w, "")
+
+	// Port
+	defaultPort := fc.Port
+	if defaultPort == 0 {
+		defaultPort = 9080
+	}
+	fmt.Fprintf(w, "Listen port [%d]:\n", defaultPort)
+	portStr := promptString(scanner, w, strconv.Itoa(defaultPort))
+	if p, err := strconv.Atoi(portStr); err == nil && p > 0 {
+		fc.Port = p
+	} else {
+		fc.Port = defaultPort
+	}
+	fmt.Fprintln(w, "")
+
+	// Listen address
+	defaultListen := fc.Listen
+	if defaultListen == "" {
+		defaultListen = "127.0.0.1"
+	}
+	fmt.Fprintf(w, "Listen address [%s]:\n", defaultListen)
+	val = promptString(scanner, w, defaultListen)
+	if val == "" {
+		val = defaultListen
+	}
+	fc.Listen = val
+	fmt.Fprintln(w, "")
+
+	// Save
+	path, err := configFilePathFunc()
+	if err != nil {
+		return fmt.Errorf("cannot determine config path: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("cannot create config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(fc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("cannot marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("cannot write config file: %w", err)
+	}
+
+	fmt.Fprintf(w, "Configuration saved to %s\n", path)
+	return nil
+}
+
+// promptString displays "> " and reads one line. If the input is empty, returns defaultVal.
+func promptString(scanner *bufio.Scanner, w io.Writer, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Fprintf(w, "> [%s] ", defaultVal)
+	} else {
+		fmt.Fprint(w, "> ")
+	}
+	if scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			return line
+		}
+	}
+	return defaultVal
+}

--- a/internal/config/configure_test.go
+++ b/internal/config/configure_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunConfigure(t *testing.T) {
+	// Use a temp dir as config dir
+	tmpDir := t.TempDir()
+	origFunc := configFilePathFunc
+	configFilePathFunc = func() (string, error) {
+		return filepath.Join(tmpDir, "config.json"), nil
+	}
+	defer func() { configFilePathFunc = origFunc }()
+
+	input := "https://www.plantuml.com/plantuml\ndark\n8080\n0.0.0.0\n"
+	var out bytes.Buffer
+
+	err := RunConfigure(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("RunConfigure() error = %v", err)
+	}
+
+	// Verify output contains expected prompts
+	output := out.String()
+	if !strings.Contains(output, "markdown-proxy configuration") {
+		t.Error("output should contain header")
+	}
+	if !strings.Contains(output, "WARNING: Diagram content will be sent") {
+		t.Error("output should contain PlantUML warning")
+	}
+	if !strings.Contains(output, "Configuration saved to") {
+		t.Error("output should contain save confirmation")
+	}
+
+	// Verify saved file
+	data, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	if err != nil {
+		t.Fatalf("cannot read config file: %v", err)
+	}
+
+	var fc fileConfig
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("cannot parse config file: %v", err)
+	}
+
+	if fc.PlantUMLServer != "https://www.plantuml.com/plantuml" {
+		t.Errorf("PlantUMLServer = %q, want %q", fc.PlantUMLServer, "https://www.plantuml.com/plantuml")
+	}
+	if fc.Theme != "dark" {
+		t.Errorf("Theme = %q, want %q", fc.Theme, "dark")
+	}
+	if fc.Port != 8080 {
+		t.Errorf("Port = %d, want %d", fc.Port, 8080)
+	}
+	if fc.Listen != "0.0.0.0" {
+		t.Errorf("Listen = %q, want %q", fc.Listen, "0.0.0.0")
+	}
+}
+
+func TestRunConfigure_Defaults(t *testing.T) {
+	// Use a temp dir as config dir
+	tmpDir := t.TempDir()
+	origFunc := configFilePathFunc
+	configFilePathFunc = func() (string, error) {
+		return filepath.Join(tmpDir, "config.json"), nil
+	}
+	defer func() { configFilePathFunc = origFunc }()
+
+	// All empty inputs → use defaults
+	input := "\n\n\n\n"
+	var out bytes.Buffer
+
+	err := RunConfigure(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("RunConfigure() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	if err != nil {
+		t.Fatalf("cannot read config file: %v", err)
+	}
+
+	var fc fileConfig
+	if err := json.Unmarshal(data, &fc); err != nil {
+		t.Fatalf("cannot parse config file: %v", err)
+	}
+
+	if fc.PlantUMLServer != "" {
+		t.Errorf("PlantUMLServer = %q, want empty", fc.PlantUMLServer)
+	}
+	if fc.Theme != "github" {
+		t.Errorf("Theme = %q, want %q", fc.Theme, "github")
+	}
+	if fc.Port != 9080 {
+		t.Errorf("Port = %d, want %d", fc.Port, 9080)
+	}
+	if fc.Listen != "127.0.0.1" {
+		t.Errorf("Listen = %q, want %q", fc.Listen, "127.0.0.1")
+	}
+}
+
+func TestRunConfigure_ExistingConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	origFunc := configFilePathFunc
+	configFilePathFunc = func() (string, error) {
+		return filepath.Join(tmpDir, "config.json"), nil
+	}
+	defer func() { configFilePathFunc = origFunc }()
+
+	// Write an existing config
+	existing := fileConfig{
+		PlantUMLServer: "https://plantuml.example.com",
+		Theme:          "simple",
+		Port:           3000,
+		Listen:         "192.168.1.10",
+	}
+	data, _ := json.Marshal(existing)
+	os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644)
+
+	// All empty inputs → keep existing values
+	input := "\n\n\n\n"
+	var out bytes.Buffer
+
+	err := RunConfigure(strings.NewReader(input), &out)
+	if err != nil {
+		t.Fatalf("RunConfigure() error = %v", err)
+	}
+
+	output := out.String()
+	// Verify existing values shown as defaults
+	if !strings.Contains(output, "https://plantuml.example.com") {
+		t.Error("output should show existing PlantUML server as default")
+	}
+	if !strings.Contains(output, "simple") {
+		t.Error("output should show existing theme as default")
+	}
+	if !strings.Contains(output, "3000") {
+		t.Error("output should show existing port as default")
+	}
+
+	// Verify values preserved
+	data, _ = os.ReadFile(filepath.Join(tmpDir, "config.json"))
+	var fc fileConfig
+	json.Unmarshal(data, &fc)
+
+	if fc.PlantUMLServer != "https://plantuml.example.com" {
+		t.Errorf("PlantUMLServer = %q, want preserved value", fc.PlantUMLServer)
+	}
+	if fc.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", fc.Port)
+	}
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origFunc := configFilePathFunc
+	configFilePathFunc = func() (string, error) {
+		return filepath.Join(tmpDir, "config.json"), nil
+	}
+	defer func() { configFilePathFunc = origFunc }()
+
+	// No file → zero values
+	fc := loadConfigFile()
+	if fc.PlantUMLServer != "" || fc.Theme != "" || fc.Port != 0 {
+		t.Errorf("loadConfigFile() with no file should return zero values, got %+v", fc)
+	}
+
+	// Write a config file
+	config := `{"plantuml-server": "https://example.com/plantuml", "theme": "dark", "port": 7070}`
+	os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(config), 0644)
+
+	fc = loadConfigFile()
+	if fc.PlantUMLServer != "https://example.com/plantuml" {
+		t.Errorf("PlantUMLServer = %q, want %q", fc.PlantUMLServer, "https://example.com/plantuml")
+	}
+	if fc.Theme != "dark" {
+		t.Errorf("Theme = %q, want %q", fc.Theme, "dark")
+	}
+	if fc.Port != 7070 {
+		t.Errorf("Port = %d, want %d", fc.Port, 7070)
+	}
+}
+
+func TestLoadConfigFile_InvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	origFunc := configFilePathFunc
+	configFilePathFunc = func() (string, error) {
+		return filepath.Join(tmpDir, "config.json"), nil
+	}
+	defer func() { configFilePathFunc = origFunc }()
+
+	os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("not json"), 0644)
+
+	fc := loadConfigFile()
+	if fc.PlantUMLServer != "" || fc.Theme != "" || fc.Port != 0 {
+		t.Errorf("loadConfigFile() with invalid JSON should return zero values, got %+v", fc)
+	}
+}

--- a/internal/markdown/codeblock.go
+++ b/internal/markdown/codeblock.go
@@ -33,7 +33,11 @@ func PreprocessCodeBlocks(source []byte, plantumlServer string) []byte {
 				imgURL := fmt.Sprintf("%s/svg/%s", strings.TrimRight(plantumlServer, "/"), encoded)
 				return []byte(fmt.Sprintf("\n<div class=\"plantuml-container\"><img src=\"%s\" alt=\"PlantUML diagram\"></div>\n", imgURL))
 			}
-			return match
+			return []byte("\n<div class=\"plantuml-notice\">" +
+				"<strong>PlantUML rendering is disabled.</strong> " +
+				"To enable, start with <code>--plantuml-server URL</code> " +
+				"or run <code>markdown-proxy --configure</code> to set up." +
+				"</div>\n")
 		}
 		return match
 	})

--- a/internal/markdown/codeblock_test.go
+++ b/internal/markdown/codeblock_test.go
@@ -1,0 +1,84 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreprocessCodeBlocks_PlantUMLWithServer(t *testing.T) {
+	input := []byte("```plantuml\n@startuml\nAlice -> Bob\n@enduml\n```\n")
+	result := PreprocessCodeBlocks(input, "https://www.plantuml.com/plantuml")
+	s := string(result)
+
+	if !strings.Contains(s, "plantuml-container") {
+		t.Error("should render PlantUML image when server is configured")
+	}
+	if !strings.Contains(s, "<img src=") {
+		t.Error("should contain img tag")
+	}
+	if strings.Contains(s, "plantuml-notice") {
+		t.Error("should not show notice when server is configured")
+	}
+}
+
+func TestPreprocessCodeBlocks_PlantUMLWithoutServer(t *testing.T) {
+	input := []byte("```plantuml\n@startuml\nAlice -> Bob\n@enduml\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+	s := string(result)
+
+	if !strings.Contains(s, "plantuml-notice") {
+		t.Error("should show notice when server is not configured")
+	}
+	if !strings.Contains(s, "PlantUML rendering is disabled") {
+		t.Error("notice should contain disabled message")
+	}
+	if !strings.Contains(s, "--plantuml-server") {
+		t.Error("notice should mention --plantuml-server flag")
+	}
+	if !strings.Contains(s, "--configure") {
+		t.Error("notice should mention --configure option")
+	}
+	if strings.Contains(s, "plantuml-container") {
+		t.Error("should not render PlantUML image when server is not configured")
+	}
+}
+
+func TestPreprocessCodeBlocks_SVG(t *testing.T) {
+	input := []byte("```svg\n<svg><circle/></svg>\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+	s := string(result)
+
+	if !strings.Contains(s, "svg-container") {
+		t.Error("should render SVG container")
+	}
+}
+
+func TestPreprocessCodeBlocks_Mermaid(t *testing.T) {
+	input := []byte("```mermaid\ngraph TD\n  A-->B\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+	s := string(result)
+
+	if !strings.Contains(s, `class="mermaid"`) {
+		t.Error("should render mermaid pre tag")
+	}
+}
+
+func TestPreprocessCodeBlocks_NoSpecialBlocks(t *testing.T) {
+	input := []byte("```go\nfmt.Println(\"hello\")\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+
+	if string(result) != string(input) {
+		t.Error("should not modify non-special code blocks")
+	}
+}
+
+func TestPreprocessCodeBlocks_MultiplePlantUMLBlocks(t *testing.T) {
+	input := []byte("```plantuml\n@startuml\nA->B\n@enduml\n```\n\ntext\n\n```plantuml\n@startuml\nC->D\n@enduml\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+	s := string(result)
+
+	count := strings.Count(s, "plantuml-notice")
+	if count != 2 {
+		t.Errorf("should show 2 notices, got %d", count)
+	}
+}

--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -29,6 +29,36 @@ body { margin: 0; padding: 0; }
 .markdown-body pre.text-file {
   white-space: pre-wrap;
 }
+.plantuml-notice {
+  padding: 12px 16px;
+  margin: 16px 0;
+  border-radius: 6px;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.plantuml-notice code {
+  padding: .2em .4em;
+  border-radius: 3px;
+  font-size: 85%;
+}
+.theme-github .plantuml-notice,
+.theme-simple .plantuml-notice {
+  background: #fff8c5;
+  border: 1px solid #d4a72c;
+  color: #4d3800;
+}
+.theme-github .plantuml-notice code,
+.theme-simple .plantuml-notice code {
+  background: rgba(0,0,0,.08);
+}
+.theme-dark .plantuml-notice {
+  background: #2d2a1e;
+  border: 1px solid #966c00;
+  color: #e3b341;
+}
+.theme-dark .plantuml-notice code {
+  background: rgba(255,255,255,.1);
+}
 .markdown-body {
   max-width: 980px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- Load persistent settings from `~/.config/markdown-proxy/config.json` (cross-platform via `os.UserConfigDir()`)
- Add `--configure` flag for interactive config file creation with PlantUML security warning
- Show informational hint in place of PlantUML code blocks when `--plantuml-server` is not configured
- CLI flags override config file values; sensitive settings (`auth-token`, etc.) are excluded from config file

## Test plan
- [x] `go test ./...` passes (11 new tests added for config and codeblock processing)
- [x] `markdown-proxy --configure` creates config file interactively
- [x] Config file values are used as defaults when starting server
- [x] CLI flags override config file values
- [x] PlantUML blocks show notice when server is not configured
- [x] PlantUML blocks render normally when server is configured
- [x] Notice styling works across all three themes (github, simple, dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)