### PR TITLE
Add file argument support to open files directly in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,17 @@ How markdown-proxy compares to other Markdown viewing tools:
 # Install
 go install github.com/patakuti/markdown-proxy/cmd/markdown-proxy@latest
 
-# Start the server
-markdown-proxy
+# Open a file directly (starts server automatically if needed)
+markdown-proxy README.md
 
-# Open in browser
-open http://localhost:9080/
+# Open a remote URL
+markdown-proxy https://github.com/user/repo
+
+# Or start the server manually and browse to http://localhost:9080/
+markdown-proxy
 ```
 
-Enter a local file path (e.g., `/path/to/README.md`) or a remote URL (e.g., `https://github.com/user/repo`) on the top page.
+When a file or URL is given as an argument, markdown-proxy checks if the server is already running; if not, it starts one in the background. Then it opens the file in your default browser. Without arguments, it starts the server in the foreground as before.
 
 ## Use Cases
 
@@ -125,8 +128,18 @@ When navigating to a line anchor (`#L12` or `#L12-L34`), the page scrolls to the
 ## Usage
 
 ```bash
-markdown-proxy [options]
+markdown-proxy [options] [file-or-url]
 ```
+
+When `file-or-url` is provided:
+- **Local file**: Opens the file via the proxy (relative paths are resolved automatically)
+  - `markdown-proxy README.md`
+  - `markdown-proxy ../docs/design.md`
+  - `markdown-proxy /absolute/path/to/file.md`
+- **Remote URL**: Opens the URL via the proxy
+  - `markdown-proxy https://github.com/user/repo`
+- If the server is not already running, it is started automatically in the background
+- The file is opened in the default browser (`xdg-open` on Linux, `start` on Windows, `open` on macOS)
 
 ### Options
 

--- a/cmd/markdown-proxy/main.go
+++ b/cmd/markdown-proxy/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/patakuti/markdown-proxy/internal/config"
+	"github.com/patakuti/markdown-proxy/internal/opener"
 	"github.com/patakuti/markdown-proxy/internal/server"
 )
 
@@ -25,10 +26,59 @@ func main() {
 		}
 		return
 	}
+
+	// If a file or URL argument is provided, open it in the browser.
+	if args := flag.Args(); len(args) > 0 {
+		if err := openFile(cfg, args[0]); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
+
 	if err := cfg.Validate(); err != nil {
 		log.Fatal(err)
 	}
 	if err := server.Run(cfg); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// openFile builds the proxy URL for the given argument, ensures the server
+// is running, and opens the URL in the default browser.
+func openFile(cfg *config.Config, arg string) error {
+	proxyURL, err := opener.BuildURL(arg, cfg.Port)
+	if err != nil {
+		return err
+	}
+
+	if !opener.IsServerRunning(cfg.Port) {
+		log.Printf("Starting server on port %d...", cfg.Port)
+		serverArgs := buildServerArgs()
+		if err := opener.StartServer(cfg.Port, serverArgs); err != nil {
+			return err
+		}
+	}
+
+	log.Printf("Opening %s", proxyURL)
+	return opener.OpenBrowser(proxyURL)
+}
+
+// buildServerArgs collects the explicitly specified command-line flags
+// to pass to the background server process.
+func buildServerArgs() []string {
+	return collectServerArgs(flag.Visit)
+}
+
+// collectServerArgs extracts flags using the provided visit function.
+// This is separated from buildServerArgs to allow testing.
+func collectServerArgs(visit func(func(*flag.Flag))) []string {
+	var args []string
+	visit(func(f *flag.Flag) {
+		// Skip flags that are not relevant for the server process.
+		if f.Name == "version" {
+			return
+		}
+		args = append(args, fmt.Sprintf("-%s=%s", f.Name, f.Value.String()))
+	})
+	return args
 }

--- a/cmd/markdown-proxy/main_test.go
+++ b/cmd/markdown-proxy/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestCollectServerArgs_Basic(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("port", "9080", "")
+	fs.String("theme", "github", "")
+	fs.Parse([]string{"-port=8080", "-theme=dark"})
+
+	args := collectServerArgs(fs.Visit)
+	want := []string{"-port=8080", "-theme=dark"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("got %v, want %v", args, want)
+	}
+}
+
+func TestCollectServerArgs_SkipsVersion(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Bool("version", false, "")
+	fs.String("port", "9080", "")
+	fs.Parse([]string{"-version", "-port=8080"})
+
+	args := collectServerArgs(fs.Visit)
+	want := []string{"-port=8080"}
+	if !reflect.DeepEqual(args, want) {
+		t.Errorf("got %v, want %v", args, want)
+	}
+}
+
+func TestCollectServerArgs_NoFlags(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("port", "9080", "")
+	fs.Parse([]string{})
+
+	args := collectServerArgs(fs.Visit)
+	if args != nil {
+		t.Errorf("got %v, want nil", args)
+	}
+}

--- a/internal/opener/opener.go
+++ b/internal/opener/opener.go
@@ -1,0 +1,98 @@
+package opener
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// BuildURL converts a file path or URL argument into a proxy URL.
+// For local files, relative paths are resolved to absolute paths.
+// For remote URLs (http:// or https://), the scheme is converted to a path prefix.
+func BuildURL(arg string, port int) (string, error) {
+	base := fmt.Sprintf("http://localhost:%d", port)
+
+	if strings.HasPrefix(arg, "http://") {
+		return base + "/http/" + strings.TrimPrefix(arg, "http://"), nil
+	}
+	if strings.HasPrefix(arg, "https://") {
+		return base + "/https/" + strings.TrimPrefix(arg, "https://"), nil
+	}
+
+	// Local file path
+	absPath, err := filepath.Abs(arg)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve path %q: %w", arg, err)
+	}
+	// Convert to forward slashes for URL (Windows compatibility)
+	urlPath := filepath.ToSlash(absPath)
+	return base + "/local/" + strings.TrimPrefix(urlPath, "/"), nil
+}
+
+// IsServerRunning checks if a server is already listening on the given port.
+func IsServerRunning(port int) bool {
+	addr := fmt.Sprintf("localhost:%d", port)
+	conn, err := net.DialTimeout("tcp", addr, 1*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// StartServer launches a new server process in the background and waits
+// for it to become ready. The provided args should be the command-line
+// flags to pass to the server (excluding the file argument).
+func StartServer(port int, args []string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	cmd := exec.Command(exe, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Detach the child process so it survives after this process exits.
+	setSysProcAttr(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start server: %w", err)
+	}
+
+	// Wait for the server to become ready (up to 5 seconds).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if IsServerRunning(port) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("server did not start within 5 seconds")
+}
+
+// OpenBrowser opens the given URL in the default browser.
+func OpenBrowser(rawURL string) error {
+	// Validate that it's a proper URL before passing to the shell.
+	if _, err := url.Parse(rawURL); err != nil {
+		return fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		cmd = exec.Command("xdg-open", rawURL)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", rawURL)
+	case "darwin":
+		cmd = exec.Command("open", rawURL)
+	default:
+		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
+	}
+	return cmd.Start()
+}

--- a/internal/opener/opener_test.go
+++ b/internal/opener/opener_test.go
@@ -1,0 +1,113 @@
+package opener
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestBuildURL_LocalAbsolute(t *testing.T) {
+	url, err := BuildURL("/home/user/doc.md", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:9080/local/home/user/doc.md"
+	if url != want {
+		t.Errorf("got %q, want %q", url, want)
+	}
+}
+
+func TestBuildURL_LocalRelative(t *testing.T) {
+	url, err := BuildURL("file.md", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(url, "http://localhost:9080/local/") {
+		t.Errorf("expected /local/ prefix, got %q", url)
+	}
+	if !strings.HasSuffix(url, "/file.md") {
+		t.Errorf("expected to end with /file.md, got %q", url)
+	}
+}
+
+func TestBuildURL_HTTPS(t *testing.T) {
+	url, err := BuildURL("https://github.com/user/repo", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:9080/https/github.com/user/repo"
+	if url != want {
+		t.Errorf("got %q, want %q", url, want)
+	}
+}
+
+func TestBuildURL_HTTP(t *testing.T) {
+	url, err := BuildURL("http://example.com/doc.md", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:9080/http/example.com/doc.md"
+	if url != want {
+		t.Errorf("got %q, want %q", url, want)
+	}
+}
+
+func TestBuildURL_CustomPort(t *testing.T) {
+	url, err := BuildURL("file.md", 8080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(url, "http://localhost:8080/local/") {
+		t.Errorf("expected port 8080, got %q", url)
+	}
+}
+
+func TestBuildURL_RelativeParentDir(t *testing.T) {
+	url, err := BuildURL("../other/file.md", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(url, "http://localhost:9080/local/") {
+		t.Errorf("expected /local/ prefix, got %q", url)
+	}
+	// Should not contain ".." after resolution
+	if strings.Contains(url, "..") {
+		t.Errorf("expected resolved path without '..', got %q", url)
+	}
+	if !strings.HasSuffix(url, "/other/file.md") {
+		t.Errorf("expected to end with /other/file.md, got %q", url)
+	}
+}
+
+func TestBuildURL_HTTPSWithPath(t *testing.T) {
+	url, err := BuildURL("https://github.com/user/repo/blob/main/README.md", 9080)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "http://localhost:9080/https/github.com/user/repo/blob/main/README.md"
+	if url != want {
+		t.Errorf("got %q, want %q", url, want)
+	}
+}
+
+func TestIsServerRunning_NoServer(t *testing.T) {
+	// Use a port that is very unlikely to be in use.
+	if IsServerRunning(19999) {
+		t.Error("expected no server running on port 19999")
+	}
+}
+
+func TestIsServerRunning_WithServer(t *testing.T) {
+	// Start a temporary TCP listener.
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Extract the port from the listener address.
+	port := ln.Addr().(*net.TCPAddr).Port
+	if !IsServerRunning(port) {
+		t.Errorf("expected server running on port %d", port)
+	}
+}

--- a/internal/opener/proc_unix.go
+++ b/internal/opener/proc_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package opener
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr configures the command to run in a new process group
+// so it is not killed when the parent process exits.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}

--- a/internal/opener/proc_windows.go
+++ b/internal/opener/proc_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package opener
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setSysProcAttr configures the command to run detached from the parent
+// so it survives after the parent process exits.
+func setSysProcAttr(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}


### PR DESCRIPTION
## Summary

Closes #40

- Add positional argument support: `markdown-proxy [options] [file-or-url]`
- Auto-detect and reuse existing server, or start one in the background
- Open the specified file in the default browser
- Support relative/absolute local paths and remote URLs (http/https)

## Changes

- `internal/opener/`: New package with `BuildURL`, `IsServerRunning`, `StartServer`, `OpenBrowser`
- `internal/opener/proc_unix.go` / `proc_windows.go`: Platform-specific process detachment
- `cmd/markdown-proxy/main.go`: Handle `flag.Args()` for file argument, collect flags for background server
- `README.md`: Updated Quick Start and Usage sections

## Test plan

- [x] `go test ./...` passes
- [x] `make build` succeeds
- [x] Manual: `markdown-proxy README.md` opens file in browser (server auto-starts)
- [x] Manual: `markdown-proxy README.md` reuses running server
- [x] Manual: `markdown-proxy https://github.com/user/repo` opens remote URL
- [x] Manual: `markdown-proxy` without args starts server as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)