### PR TITLE
Fix display math not rendering inside blockquotes

### DIFF
--- a/internal/markdown/mathblock.go
+++ b/internal/markdown/mathblock.go
@@ -19,6 +19,8 @@ var fenceStartRe = regexp.MustCompile(`^(\x60{3,}|~{3,})`)
 //   - Opening with content: $$content...\n → $$\ncontent...\n
 //   - Closing with content: ...content$$ → ...content\n$$
 //
+// Blockquote prefixes ("> ") are stripped before detection and re-added
+// to each output line, so math blocks inside blockquotes are handled.
 // Fenced code blocks are skipped to avoid modifying code content.
 // Only exactly two consecutive $ characters are treated as delimiters
 // ($$$ or more are left for goldmark-mathjax to handle directly).
@@ -28,11 +30,15 @@ func PreprocessMathBlocks(source []byte) []byte {
 	var inFence bool
 	var fenceMarker []byte
 	var inMathBlock bool
+	var mathBlockPrefix []byte // blockquote prefix captured at math block open
 
 	for _, line := range lines {
+		// Extract blockquote prefix (e.g. "> ", ">> ", "> > ")
+		bqPrefix, body := splitBlockquotePrefix(line)
+
 		if inFence {
 			// Check if this line closes the fence
-			if m := fenceStartRe.FindSubmatch(line); m != nil {
+			if m := fenceStartRe.FindSubmatch(body); m != nil {
 				marker := m[1]
 				if marker[0] == fenceMarker[0] && len(marker) >= len(fenceMarker) {
 					inFence = false
@@ -44,7 +50,7 @@ func PreprocessMathBlocks(source []byte) []byte {
 		}
 
 		// Check if this line opens a fenced code block
-		if m := fenceStartRe.FindSubmatch(line); m != nil {
+		if m := fenceStartRe.FindSubmatch(body); m != nil {
 			inFence = true
 			fenceMarker = m[1]
 			result = append(result, line)
@@ -52,48 +58,50 @@ func PreprocessMathBlocks(source []byte) []byte {
 		}
 
 		if inMathBlock {
-			trimmed := bytes.TrimRight(line, " \t")
+			trimmed := bytes.TrimRight(body, " \t")
 			if countConsecutiveDollarsAt(trimmed, len(trimmed)-2) == 2 {
 				before := trimmed[:len(trimmed)-2]
 				if len(bytes.TrimSpace(before)) > 0 {
 					// Content before closing $$ → split
-					result = append(result, before)
-					result = append(result, []byte("$$"))
+					result = append(result, prefixed(mathBlockPrefix, before))
+					result = append(result, prefixed(mathBlockPrefix, []byte("$$")))
 				} else {
 					// Just $$ → proper closing delimiter
 					result = append(result, line)
 				}
 				inMathBlock = false
+				mathBlockPrefix = nil
 			} else {
 				result = append(result, line)
 			}
 			continue
 		}
 
-		// Check for single-line $$...$$ pattern
-		if sm := singleLineMathRe.FindSubmatch(line); sm != nil {
+		// Check for single-line $$...$$ pattern (applied to body after stripping bqPrefix)
+		if sm := singleLineMathRe.FindSubmatch(body); sm != nil {
 			indent := sm[1]
 			content := sm[2]
-			result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
-			result = append(result, append(append([]byte{}, indent...), content...))
-			result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
+			result = append(result, prefixed(bqPrefix, append(append([]byte{}, indent...), []byte("$$")...)))
+			result = append(result, prefixed(bqPrefix, append(append([]byte{}, indent...), content...)))
+			result = append(result, prefixed(bqPrefix, append(append([]byte{}, indent...), []byte("$$")...)))
 			continue
 		}
 
 		// Check for opening $$ (exactly 2 consecutive $)
-		trimmed := bytes.TrimLeft(line, " \t")
+		trimmed := bytes.TrimLeft(body, " \t")
 		if countConsecutiveDollarsAt(trimmed, 0) == 2 {
-			indent := line[:len(line)-len(trimmed)]
+			indent := body[:len(body)-len(trimmed)]
 			content := trimmed[2:]
 			if len(bytes.TrimSpace(content)) > 0 {
 				// $$ followed by content → split
-				result = append(result, append(append([]byte{}, indent...), []byte("$$")...))
-				result = append(result, append(append([]byte{}, indent...), content...))
+				result = append(result, prefixed(bqPrefix, append(append([]byte{}, indent...), []byte("$$")...)))
+				result = append(result, prefixed(bqPrefix, append(append([]byte{}, indent...), content...)))
 			} else {
 				// Just $$ → opening delimiter
 				result = append(result, line)
 			}
 			inMathBlock = true
+			mathBlockPrefix = bqPrefix
 			continue
 		}
 
@@ -101,6 +109,44 @@ func PreprocessMathBlocks(source []byte) []byte {
 	}
 
 	return bytes.Join(result, []byte("\n"))
+}
+
+// splitBlockquotePrefix extracts the leading blockquote markers from a line.
+// For example, "> > text" returns ([]byte("> > "), []byte("text")).
+// If there is no blockquote prefix, it returns (nil, line).
+func splitBlockquotePrefix(line []byte) (prefix, body []byte) {
+	i := 0
+	for i < len(line) {
+		// Skip optional leading spaces (up to 3, per CommonMark)
+		spaces := 0
+		for spaces < 3 && i+spaces < len(line) && line[i+spaces] == ' ' {
+			spaces++
+		}
+		if i+spaces < len(line) && line[i+spaces] == '>' {
+			i += spaces + 1
+			// Skip one optional space after '>'
+			if i < len(line) && line[i] == ' ' {
+				i++
+			}
+		} else {
+			break
+		}
+	}
+	if i == 0 {
+		return nil, line
+	}
+	return line[:i], line[i:]
+}
+
+// prefixed prepends a blockquote prefix to content, returning a new slice.
+func prefixed(prefix, content []byte) []byte {
+	if len(prefix) == 0 {
+		return content
+	}
+	out := make([]byte, len(prefix)+len(content))
+	copy(out, prefix)
+	copy(out[len(prefix):], content)
+	return out
 }
 
 // countConsecutiveDollarsAt counts how many consecutive '$' characters

--- a/internal/markdown/mathblock_test.go
+++ b/internal/markdown/mathblock_test.go
@@ -147,6 +147,43 @@ func TestPreprocessMathBlocks(t *testing.T) {
 			input:  "````\n```\n$$a=b$$\n```\n````\n$$x=1$$",
 			expect: "````\n```\n$$a=b$$\n```\n````\n$$\nx=1\n$$",
 		},
+
+		// Blockquote cases
+		{
+			name:   "blockquote single-line display math",
+			input:  "> $$ a = b $$",
+			expect: "> $$\n>  a = b \n> $$",
+		},
+		{
+			name:   "blockquote opening $$ with content",
+			input:  "> $$\\begin{aligned}\n> a=b\n> $$",
+			expect: "> $$\n> \\begin{aligned}\n> a=b\n> $$",
+		},
+		{
+			name:   "blockquote closing $$ with content",
+			input:  "> $$\n> a=b$$",
+			expect: "> $$\n> a=b\n> $$",
+		},
+		{
+			name:   "blockquote multi-line unchanged",
+			input:  "> $$\n> a=b\n> $$",
+			expect: "> $$\n> a=b\n> $$",
+		},
+		{
+			name:   "nested blockquote single-line",
+			input:  "> > $$a=b$$",
+			expect: "> > $$\n> > a=b\n> > $$",
+		},
+		{
+			name:   "blockquote fenced code block unchanged",
+			input:  "> ```\n> $$a=b$$\n> ```",
+			expect: "> ```\n> $$a=b$$\n> ```",
+		},
+		{
+			name:   "blockquote mixed content",
+			input:  "> text\n>\n> $$E=mc^2$$\n>\n> more text",
+			expect: "> text\n>\n> $$\n> E=mc^2\n> $$\n>\n> more text",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Fix `PreprocessMathBlocks` to handle blockquote prefixes (`> `) when splitting `$$` delimiters
- Add `splitBlockquotePrefix()` to extract blockquote markers before `$$` pattern detection
- Support nested blockquotes and fenced code blocks inside blockquotes

Closes #43

## Test plan

- [x] All existing `TestPreprocessMathBlocks` tests pass (no regression)
- [x] 7 new blockquote-specific test cases added and passing
- [x] Verified `Convert()` output contains math content inside `<blockquote>` tags
- [x] Manual test: open a Markdown file with `> $$ a = b $$` in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)