### PR TITLE
Fix SVG code blocks with blank lines not rendering

### DIFF
--- a/internal/markdown/codeblock.go
+++ b/internal/markdown/codeblock.go
@@ -24,6 +24,10 @@ func PreprocessCodeBlocks(source []byte, plantumlServer string) []byte {
 
 		switch lang {
 		case "svg":
+			// Remove blank lines from SVG content to prevent goldmark from
+			// splitting the HTML block (CommonMark HTML block type 6 ends at
+			// a blank line).
+			code = removeBlankLines(code)
 			return []byte(fmt.Sprintf("\n<div class=\"svg-container\">\n%s</div>\n", code))
 		case "mermaid":
 			return []byte(fmt.Sprintf("\n<pre class=\"mermaid\">\n%s</pre>\n", code))
@@ -41,6 +45,18 @@ func PreprocessCodeBlocks(source []byte, plantumlServer string) []byte {
 		}
 		return match
 	})
+}
+
+// removeBlankLines removes blank lines (empty or whitespace-only) from the text.
+func removeBlankLines(s string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(s, "\n") {
+		if strings.TrimSpace(line) != "" {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
 }
 
 // encodePlantUML encodes PlantUML text for the PlantUML server URL.

--- a/internal/markdown/codeblock_test.go
+++ b/internal/markdown/codeblock_test.go
@@ -53,6 +53,25 @@ func TestPreprocessCodeBlocks_SVG(t *testing.T) {
 	}
 }
 
+func TestPreprocessCodeBlocks_SVGWithBlankLines(t *testing.T) {
+	input := []byte("```svg\n<svg xmlns=\"http://www.w3.org/2000/svg\">\n\n  <!-- comment -->\n  <rect width=\"100\" height=\"100\"/>\n\n  <circle cx=\"50\" cy=\"50\" r=\"40\"/>\n\n</svg>\n```\n")
+	result := PreprocessCodeBlocks(input, "")
+	s := string(result)
+
+	if !strings.Contains(s, "svg-container") {
+		t.Error("should render SVG container")
+	}
+	if strings.Contains(s, "\n\n") {
+		t.Error("should not contain blank lines in SVG output (would break goldmark HTML block parsing)")
+	}
+	if !strings.Contains(s, "<rect") {
+		t.Error("should preserve SVG content")
+	}
+	if !strings.Contains(s, "<circle") {
+		t.Error("should preserve SVG content")
+	}
+}
+
 func TestPreprocessCodeBlocks_Mermaid(t *testing.T) {
 	input := []byte("```mermaid\ngraph TD\n  A-->B\n```\n")
 	result := PreprocessCodeBlocks(input, "")
@@ -60,6 +79,29 @@ func TestPreprocessCodeBlocks_Mermaid(t *testing.T) {
 
 	if !strings.Contains(s, `class="mermaid"`) {
 		t.Error("should render mermaid pre tag")
+	}
+}
+
+func TestConvert_SVGWithBlankLines(t *testing.T) {
+	input := []byte("# Title\n\n```svg\n<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n\n  <rect width=\"100\" height=\"100\" fill=\"#fff\"/>\n\n  <text x=\"50\" y=\"50\">Hello</text>\n\n</svg>\n```\n\nParagraph after SVG.\n")
+	result, err := Convert(input, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(result)
+
+	if !strings.Contains(s, "svg-container") {
+		t.Error("should contain svg-container div")
+	}
+	if !strings.Contains(s, "</svg>") {
+		t.Error("should contain closing svg tag")
+	}
+	if !strings.Contains(s, "Paragraph after SVG.") {
+		t.Error("should contain paragraph after SVG")
+	}
+	// The SVG should not be broken apart by goldmark
+	if strings.Contains(s, "&lt;rect") || strings.Contains(s, "&lt;text") {
+		t.Error("SVG elements should not be HTML-escaped (goldmark should treat as HTML block)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #45

- Strip blank lines from SVG content in `PreprocessCodeBlocks` before embedding as raw HTML
- Prevents goldmark from splitting the HTML block at blank lines (CommonMark HTML block type 6 terminates at blank lines)
- Add unit test and end-to-end test for SVG with blank lines

## Test plan

- [x] `TestPreprocessCodeBlocks_SVGWithBlankLines` — verifies blank lines are removed from output
- [x] `TestConvert_SVGWithBlankLines` — verifies SVG survives full goldmark conversion without being escaped
- [x] Existing SVG/mermaid/plantuml tests pass
- [x] Manual: render an SVG with blank lines in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)