### PR TITLE
Fix math block rendering broken by CRLF line endings

### DIFF
--- a/internal/markdown/convert.go
+++ b/internal/markdown/convert.go
@@ -50,6 +50,9 @@ func init() {
 // Convert converts Markdown source to HTML.
 // plantumlServer is the PlantUML server URL for code block conversion.
 func Convert(source []byte, plantumlServer string) ([]byte, error) {
+	// Normalize CRLF to LF so all preprocessors and the parser see consistent line endings.
+	source = bytes.ReplaceAll(source, []byte("\r\n"), []byte("\n"))
+
 	// Pre-process: expand single-line $$...$$ to multi-line for goldmark-mathjax
 	source = PreprocessMathBlocks(source)
 

--- a/internal/markdown/convert_test.go
+++ b/internal/markdown/convert_test.go
@@ -1,0 +1,22 @@
+package markdown
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvert_CRLFMathBlock(t *testing.T) {
+	// Regression: CRLF line endings must not break $$ math block rendering.
+	input := []byte("$$\r\ny = x^2\r\n$$\r\n")
+	html, err := Convert(input, "")
+	if err != nil {
+		t.Fatalf("Convert returned error: %v", err)
+	}
+	s := string(html)
+	if !strings.Contains(s, `\(y = x^2\)`) && !strings.Contains(s, `y = x^2`) {
+		t.Errorf("math content missing from output:\n%s", s)
+	}
+	if strings.Contains(s, `\(\)`) || strings.Contains(s, `\(\r`) {
+		t.Errorf("CRLF leaked into math output:\n%s", s)
+	}
+}


### PR DESCRIPTION
Closes #51

## Summary

- Normalize CRLF (`\r\n`) to LF (`\n`) at the start of `Convert` so `PreprocessMathBlocks` and goldmark receive consistent line endings
- Add regression test `TestConvert_CRLFMathBlock` in `convert_test.go`

## Root cause

`PreprocessMathBlocks` splits on `\n`, leaving a trailing `\r` on each line with CRLF input.
`bytes.TrimRight(body, " \t")` does not strip `\r`, so the closing `$$\r` line was misdetected as having content `$` before the delimiter, corrupting the math block structure.

## Test plan

- [x] `go test ./internal/markdown/... -run TestConvert_CRLFMathBlock` passes
- [x] All existing tests pass (`go test ./...`)
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)