### PR TITLE
Add copy button to code blocks

### DIFF
--- a/internal/template/copybutton.go
+++ b/internal/template/copybutton.go
@@ -69,7 +69,7 @@ const copyButtonJS = `<script>
       btn.textContent = 'Copy';
       btn.addEventListener('click', function() {
         var code = pre.querySelector('code');
-        var text = (code ? code.innerText : pre.innerText).replace(/\n+$/, '');
+        var text = (code ? code.textContent : pre.textContent).replace(/\n+$/, '');
         navigator.clipboard.writeText(text).then(function() {
           btn.textContent = 'Copied!';
           btn.classList.add('copied');

--- a/internal/template/copybutton.go
+++ b/internal/template/copybutton.go
@@ -1,0 +1,89 @@
+package template
+
+const copyButtonCSS = `
+.markdown-body pre {
+  position: relative;
+}
+.copy-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  padding: 3px 8px;
+  font-size: 11px;
+  line-height: 1.5;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+.markdown-body pre:hover .copy-btn,
+.copy-btn:focus {
+  opacity: 1;
+}
+.copy-btn.copied {
+  opacity: 1;
+}
+.theme-github .copy-btn,
+.theme-simple .copy-btn {
+  background: #fff;
+  color: #444;
+  border-color: #d0d7de;
+}
+.theme-github .copy-btn:hover,
+.theme-simple .copy-btn:hover {
+  background: #f3f4f6;
+  border-color: #adb5bd;
+}
+.theme-github .copy-btn.copied,
+.theme-simple .copy-btn.copied {
+  background: #d4edda;
+  color: #155724;
+  border-color: #c3e6cb;
+}
+.theme-dark .copy-btn {
+  background: #21262d;
+  color: #c9d1d9;
+  border-color: #30363d;
+}
+.theme-dark .copy-btn:hover {
+  background: #2d333b;
+  border-color: #6e7681;
+}
+.theme-dark .copy-btn.copied {
+  background: #1a3d2b;
+  color: #3fb950;
+  border-color: #2ea043;
+}
+@media print {
+  .copy-btn { display: none !important; }
+}
+`
+
+const copyButtonJS = `<script>
+(function() {
+  document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.markdown-body pre').forEach(function(pre) {
+      var btn = document.createElement('button');
+      btn.className = 'copy-btn';
+      btn.textContent = 'Copy';
+      btn.addEventListener('click', function() {
+        var code = pre.querySelector('code');
+        var text = code ? code.innerText : pre.innerText;
+        navigator.clipboard.writeText(text).then(function() {
+          btn.textContent = 'Copied!';
+          btn.classList.add('copied');
+          setTimeout(function() {
+            btn.textContent = 'Copy';
+            btn.classList.remove('copied');
+          }, 2000);
+        }).catch(function() {
+          btn.textContent = 'Error';
+          setTimeout(function() { btn.textContent = 'Copy'; }, 2000);
+        });
+      });
+      pre.appendChild(btn);
+    });
+  });
+})();
+</script>`

--- a/internal/template/copybutton.go
+++ b/internal/template/copybutton.go
@@ -69,7 +69,7 @@ const copyButtonJS = `<script>
       btn.textContent = 'Copy';
       btn.addEventListener('click', function() {
         var code = pre.querySelector('code');
-        var text = code ? code.innerText : pre.innerText;
+        var text = (code ? code.innerText : pre.innerText).replace(/\n+$/, '');
         navigator.clipboard.writeText(text).then(function() {
           btn.textContent = 'Copied!';
           btn.classList.add('copied');

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -88,6 +88,7 @@ const markdownPageTplHead = `<!DOCTYPE html>
 <style>` + commonCSS + `</style>
 <style>` + lineAnchorCSS + `</style>
 <style>` + tocCSS + `</style>
+<style>` + copyButtonCSS + `</style>
 `
 
 const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
@@ -156,6 +157,7 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 ` + lineAnchorJS + `
 ` + tocJS + `
+` + copyButtonJS + `
 {{if .WatchPath}}
 <script>
 (function() {


### PR DESCRIPTION
## Summary

- Add a copy button to each `<pre><code>` block, displayed at the top-right corner on hover
- Clicking copies the code to the clipboard and shows "Copied!" for 2 seconds
- Styled for all themes (GitHub, Simple, Dark); hidden during printing

## Implementation

New file `internal/template/copybutton.go` following the same pattern as `toc.go` / `lineanchor.go`:
- `copyButtonCSS`: positions the button absolutely in the top-right of `pre`, with hover/focus reveal and per-theme colors
- `copyButtonJS`: injects buttons on `DOMContentLoaded`; uses `textContent` (not `innerText`) to avoid extra newlines introduced by chroma's `display: flex` on `span.line`

## Test plan

- [x] Code blocks show a copy button on hover
- [x] Clicking copies the exact code (no extra newlines) to the clipboard
- [x] "Copied!" feedback appears for ~2 seconds then resets
- [x] Works in all three themes (GitHub, Simple, Dark)
- [x] Button is hidden when printing

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)