### PR TITLE
Fix mermaid rendering, table column widths, and display math size

### DIFF
--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -45,11 +45,16 @@ body { margin: 0; padding: 0; }
 }
 .markdown-body table {
   border-collapse: collapse;
-  width: 100%;
+  width: auto;
+  table-layout: auto;
 }
 .markdown-body table th,
 .markdown-body table td {
   border: 1px solid;
   padding: 6px 13px;
+}
+.math.display {
+  font-size: 0.9em;
+  overflow-x: auto;
 }
 `

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -90,7 +90,7 @@ const markdownPageTplHead = `<!DOCTYPE html>
 
 const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
 <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
 </head>
 <body class="theme-{{.Theme}}">
 <div class="toolbar">
@@ -116,7 +116,7 @@ const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.n
   <div class="toc-body"><ul class="toc-list"></ul></div>
 </aside>
 <script>
-mermaid.initialize({startOnLoad: true, theme: document.body.className.indexOf('dark') >= 0 ? 'dark' : 'default'});
+mermaid.initialize({startOnLoad: false, theme: document.body.className.indexOf('dark') >= 0 ? 'dark' : 'default'});
 function printPage() {
   var orig = document.title;
   var name = orig.split(' - ')[0];
@@ -145,6 +145,7 @@ function switchTheme(theme) {
 </script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
+  mermaid.run();
   document.querySelectorAll('.math.inline').forEach(function(el) {
     var tex = el.textContent.replace(/^\\\(/, '').replace(/\\\)$/, '').trim();
     katex.render(tex, el, {displayMode: false, throwOnError: false});


### PR DESCRIPTION
## Summary

- **Mermaid not rendering**: The theme restore script was calling `mermaid.initialize({startOnLoad: false})` on page load, overriding the initial `startOnLoad: true` config before DOMContentLoaded fired. Fixed by switching to `startOnLoad: false` + explicit `mermaid.run()` in DOMContentLoaded. Also pinned the CDN to `mermaid@10` to prevent future breaking API changes.
- **Table column widths**: Changed `width: 100%` to `width: auto` with explicit `table-layout: auto` so each column sizes itself to its content instead of distributing space equally.
- **Display math too large**: Added `font-size: 0.9em; overflow-x: auto` to `.math.display` to reduce block math size relative to body text and handle wide formulas on narrow screens.

## Test plan

- [x] Open a page with a mermaid diagram — confirm it renders correctly
- [x] Open a page with a saved theme in localStorage — confirm mermaid still renders
- [x] Open a page with a markdown table — confirm column widths vary by content
- [x] Open a page with display math (`$$...$$`) — confirm it is slightly smaller than before and wide formulas scroll horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)