### PR TITLE
Fix print CSS partially applied due to external stylesheet timing

### DIFF
--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -119,11 +119,28 @@ const markdownPageTplTail = `<link rel="stylesheet" href="https://cdn.jsdelivr.n
 mermaid.initialize({startOnLoad: false, theme: document.body.className.indexOf('dark') >= 0 ? 'dark' : 'default'});
 function printPage() {
   var orig = document.title;
-  var name = orig.split(' - ')[0];
-  name = name.replace(/\.(md|markdown)$/i, '');
+  var name = orig.split(' - ')[0].replace(/\.(md|markdown)$/i, '');
   document.title = name;
-  window.print();
-  document.title = orig;
+
+  function doPrint() { window.print(); document.title = orig; }
+
+  var links = document.querySelectorAll('link[rel="stylesheet"]');
+  var unloaded = [];
+  for (var i = 0; i < links.length; i++) {
+    var l = links[i];
+    try { if (!l.sheet) unloaded.push(l); } catch(e) {}
+  }
+  if (unloaded.length === 0) { doPrint(); return; }
+
+  var done = false;
+  var remaining = unloaded.length;
+  function tick() { if (!done && --remaining <= 0) { done = true; doPrint(); } }
+  setTimeout(function() { if (!done) { done = true; doPrint(); } }, 3000);
+  unloaded.forEach(function(l) {
+    try { if (l.sheet) { tick(); return; } } catch(e) { tick(); return; }
+    l.addEventListener('load', tick, {once: true});
+    l.addEventListener('error', tick, {once: true});
+  });
 }
 function switchTheme(theme) {
   var classes = Array.prototype.slice.call(document.body.classList);


### PR DESCRIPTION
Closes #59

## Summary

- `printPage()` now waits for all `<link rel="stylesheet">` elements to finish loading before calling `window.print()`
- Cross-origin stylesheets (e.g. KaTeX CDN) that block `.sheet` access via CORS are skipped gracefully
- A 3-second timeout ensures the print dialog is never blocked indefinitely if a stylesheet fails to load

## Root Cause

On page load, `switchTheme()` is called with the theme from `localStorage`, which changes `href` on the theme `<link>` element and triggers a new HTTP request. Calling `window.print()` before this request completes results in a print preview without theme CSS applied.

## Test plan

- [x] Open a markdown file, confirm a non-default theme is saved in localStorage
- [x] Click **Print** immediately after page load — verify theme CSS (colors, fonts) is correctly applied in print preview
- [x] Click **Print** after page is fully loaded — verify normal behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)