### PR TITLE
Fix background colors not printed in custom theme CSS

### DIFF
--- a/internal/template/css.go
+++ b/internal/template/css.go
@@ -19,6 +19,10 @@ body { margin: 0; padding: 0; }
 .theme-switcher select { padding: 2px 6px; font-size: 13px; }
 @media print {
   .toolbar { display: none; }
+  .markdown-body, .markdown-body * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
   table, pre, .math.display, img, blockquote, li { break-inside: avoid; }
   h1, h2, h3, h4, h5, h6 { break-after: avoid; }
 }


### PR DESCRIPTION
Closes #61

## Summary

- Add `print-color-adjust: exact` and `-webkit-print-color-adjust: exact` to `.markdown-body, .markdown-body *` inside `@media print`
- Scoped to `.markdown-body` so the page/body background (e.g. dark theme's black background) is not affected

## Root Cause

Browsers ignore `background-color` and `background-image` when printing by default. Custom theme CSS like `h1 { background: #0075e2; }` was silently dropped in print preview despite being correctly applied on screen.

## Test plan

- [x] Create a custom theme CSS with `h1 { background: #0075e2; color: #fff; }` and verify the background color appears in print preview
- [x] Verify built-in themes (github, simple, dark) still look correct in print preview
- [x] Verify the dark theme body background is NOT printed (page background stays white)

🤖 Generated with [Claude Code](https://claude.com/claude-code)